### PR TITLE
[FEAT][junyong]: 스탬프 적립 API 구현

### DIFF
--- a/src/main/java/kkukmoa/kkukmoa/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kkukmoa/kkukmoa/apiPayload/code/status/ErrorStatus.java
@@ -27,15 +27,16 @@ public enum ErrorStatus implements BaseErrorCode {
     OWNER_STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "OWNER4006", "사장님 소유의 가게가 없습니다."),
 
     // 인증 관련 에러
-    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH4010", "인증에 실패했습니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH4000", "인증에 실패했습니다."),
     // QR 코드 관련 에러
-    QR_CANNOT_GENERATION(HttpStatus.BAD_REQUEST, "QR400", "QR 코드 생성에 실패했습니다."),
-    QR_INVALID(HttpStatus.NOT_FOUND, "QR401", "유효하지 않는 QR 코드입니다."),
+    QR_CANNOT_GENERATION(HttpStatus.BAD_REQUEST, "QR4001", "QR 코드 생성에 실패했습니다."),
+    QR_INVALID(HttpStatus.NOT_FOUND, "QR4002", "유효하지 않는 QR 코드입니다."),
+    QR_EXPIRED(HttpStatus.NOT_FOUND, "QR4003", "만료된 QR 코드입니다."),
 
     // 쿠폰 관련 에러
-    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "COUPON400", "존재하지 않는 쿠폰입니다."),
-    COUPON_INVALID_USED_PLACE(HttpStatus.BAD_REQUEST, "COUPON401", "올바르지 않은 사용처(사장)입니다."),
-    COUPON_IS_USED(HttpStatus.BAD_REQUEST, "COUPON402", "이미 사용한 쿠폰입니다."),
+    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "COUPON4000", "존재하지 않는 쿠폰입니다."),
+    COUPON_INVALID_USED_PLACE(HttpStatus.BAD_REQUEST, "COUPON4001", "올바르지 않은 사용처(사장)입니다."),
+    COUPON_IS_USED(HttpStatus.BAD_REQUEST, "COUPON4002", "이미 사용한 쿠폰입니다."),
 
     // S3 관련 에러
     IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "S3_4001", "업로드 된 이미지가 존재하지 않습니다.."),
@@ -55,7 +56,12 @@ public enum ErrorStatus implements BaseErrorCode {
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT4004", "결제 승인이 실패했습니다."),
     PAYMENT_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT4040", "결제 정보가 존재하지 않습니다."),
     PAYMENT_REDIS_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT5001", "결제 정보 저장에 실패했습니다."),
-    INVALID_PAYMENT_REQUEST(HttpStatus.BAD_REQUEST, "PAYMENT4005", "유효하지 않은 결제 승인 요청입니다.");
+    INVALID_PAYMENT_REQUEST(HttpStatus.BAD_REQUEST, "PAYMENT4005", "유효하지 않은 결제 승인 요청입니다."),
+
+    // 가게 관련 에러
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE4001", "존재하지 않는 가게입니다.")
+
+    ;
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/kkukmoa/kkukmoa/apiPayload/exception/handler/StoreHandler.java
+++ b/src/main/java/kkukmoa/kkukmoa/apiPayload/exception/handler/StoreHandler.java
@@ -1,0 +1,11 @@
+package kkukmoa.kkukmoa.apiPayload.exception.handler;
+
+import kkukmoa.kkukmoa.apiPayload.code.BaseErrorCode;
+import kkukmoa.kkukmoa.apiPayload.exception.GeneralException;
+
+public class StoreHandler extends GeneralException {
+
+  public StoreHandler(BaseErrorCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/kkukmoa/kkukmoa/owner/service/OwnerQueryService.java
+++ b/src/main/java/kkukmoa/kkukmoa/owner/service/OwnerQueryService.java
@@ -29,6 +29,8 @@ public class OwnerQueryService {
     private final StoreRepository storeRepository;
     private final RedisTemplate<String, String> redisTemplate;
 
+    private int qrCodeExpirationTime = 300;
+
     /**
      * 스탬프의 QR 코드를 생성하고 반환합니다. QR 코드 생성 시, QR 코드 정보를
      *
@@ -81,10 +83,10 @@ public class OwnerQueryService {
 
         // 새로운 QR 소스 저장
         // key: storeId, value: QR
-        redisTemplate.opsForValue().set(qrCodeKey, qrSource, 60, TimeUnit.SECONDS);
+        redisTemplate.opsForValue().set(qrCodeKey, qrSource, qrCodeExpirationTime, TimeUnit.SECONDS);
 
         // key: QR, value: storeId
-        redisTemplate.opsForValue().set(qrStoreKey, storeId, 60, TimeUnit.SECONDS);
+        redisTemplate.opsForValue().set(qrStoreKey, storeId, qrCodeExpirationTime, TimeUnit.SECONDS);
 
         log.info("새로 생성한 qrSource = {}", qrSource);
     }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/controller/StampController.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/controller/StampController.java
@@ -11,12 +11,14 @@ import kkukmoa.kkukmoa.stamp.dto.stampDto.StampResponseDto;
 import kkukmoa.kkukmoa.stamp.dto.stampDto.StampResponseDto.StampListDto;
 import kkukmoa.kkukmoa.stamp.service.coupon.CouponCommandService;
 import kkukmoa.kkukmoa.stamp.service.coupon.CouponQueryService;
+import kkukmoa.kkukmoa.stamp.service.stamp.StampCommandService;
 import kkukmoa.kkukmoa.stamp.service.stamp.StampQueryService;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class StampController {
 
+    private final StampCommandService stampCommandService;
     private final StampQueryService stampQueryService;
     private final CouponQueryService couponQueryService;
     private final CouponCommandService couponCommandService;
@@ -54,4 +57,12 @@ public class StampController {
     public ResponseEntity<Coupon> makeCoupon() {
         return ResponseEntity.ok(couponCommandService.saveCoupon());
     }
+
+    @PutMapping("/coupons")
+    @Operation(summary = "스탬프 적립 API", description = "QR 코드 정보를 이용하여 스탬프를 적립합니다.<br>스탬프가 10개 적립되면 쿠폰을 발급합니다.")
+    public ApiResponse<StampResponseDto.StampSaveDto> saveCoupon(@RequestParam("qr") String qrCode) {
+        StampResponseDto.StampSaveDto saveDto = stampCommandService.save(qrCode);
+        return ApiResponse.onSuccess(saveDto);
+    }
+
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/domain/Coupon.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/domain/Coupon.java
@@ -1,6 +1,5 @@
 package kkukmoa.kkukmoa.stamp.domain;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -50,15 +49,15 @@ public class Coupon {
     //  @Column(columnDefinition = "MEDIUMBLOB")
     //  private byte[] qrImage;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 255)
     private String qrCode;
 
     // 연관관계 매핑
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user; // Coupon -> User 단방향 매핑
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store; // Coupon -> Store 단방향 매핑
 

--- a/src/main/java/kkukmoa/kkukmoa/stamp/domain/Stamp.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/domain/Stamp.java
@@ -1,6 +1,5 @@
 package kkukmoa.kkukmoa.stamp.domain;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -28,6 +27,8 @@ import org.hibernate.annotations.ColumnDefault;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Stamp {
 
+    public static int maxCount = 10;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -37,11 +38,16 @@ public class Stamp {
     private Integer count;
 
     // 연관관계 매핑
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user; // Stamp -> User 단방향 매핑
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store; // Stamp -> Store 단방향 매핑
+
+    public void saveStamp(){
+        this.count++;
+    }
+
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/dto/stampDto/StampResponseDto.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/dto/stampDto/StampResponseDto.java
@@ -1,5 +1,6 @@
 package kkukmoa.kkukmoa.stamp.dto.stampDto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import lombok.Builder;
@@ -34,4 +35,12 @@ public class StampResponseDto {
         @Schema(description = "스탬프 점수", example = "8")
         Integer stampScore;
     }
+
+    @Builder
+    @Getter
+    public static class StampSaveDto{
+        @JsonProperty(value = "has_earned_coupon")
+        Boolean hasEarnedCoupon;
+    }
+
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/enums/CouponName.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/enums/CouponName.java
@@ -1,0 +1,16 @@
+package kkukmoa.kkukmoa.stamp.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CouponName {
+
+  SERVICE("서비스 쿠폰"),
+  REWARD("리워드 쿠폰")
+  ;
+
+  private final String name;
+
+}

--- a/src/main/java/kkukmoa/kkukmoa/stamp/repository/StampRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/repository/StampRepository.java
@@ -1,8 +1,10 @@
 package kkukmoa.kkukmoa.stamp.repository;
 
+import java.util.Optional;
 import kkukmoa.kkukmoa.stamp.domain.Stamp;
 import kkukmoa.kkukmoa.store.domain.Store;
 
+import kkukmoa.kkukmoa.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,4 +12,6 @@ import java.util.List;
 public interface StampRepository extends JpaRepository<Stamp, Long> {
 
     List<Stamp> findByStore(Store store);
+
+    Optional<Stamp> findByUserAndStore(User user, Store store);
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/service/stamp/StampCommandService.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/service/stamp/StampCommandService.java
@@ -1,0 +1,101 @@
+package kkukmoa.kkukmoa.stamp.service.stamp;
+
+import java.util.Optional;
+import java.util.UUID;
+import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
+import kkukmoa.kkukmoa.apiPayload.exception.handler.QrHandler;
+import kkukmoa.kkukmoa.apiPayload.exception.handler.StoreHandler;
+import kkukmoa.kkukmoa.common.enums.QrCodeType;
+import kkukmoa.kkukmoa.common.util.AuthService;
+import kkukmoa.kkukmoa.stamp.domain.Coupon;
+import kkukmoa.kkukmoa.stamp.domain.Stamp;
+import kkukmoa.kkukmoa.stamp.dto.stampDto.StampResponseDto;
+import kkukmoa.kkukmoa.stamp.enums.CouponName;
+import kkukmoa.kkukmoa.stamp.enums.CouponStatus;
+import kkukmoa.kkukmoa.stamp.repository.CouponRepository;
+import kkukmoa.kkukmoa.stamp.repository.StampRepository;
+import kkukmoa.kkukmoa.store.domain.Store;
+import kkukmoa.kkukmoa.store.repository.StoreRepository;
+import kkukmoa.kkukmoa.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StampCommandService {
+
+  private final StoreRepository storeRepository;
+  private final StampRepository stampRepository;
+  private final StringRedisTemplate stringRedisTemplate;
+  private final AuthService authService;
+  private final CouponRepository couponRepository;
+
+  // storeId를 찾기 위한 레디스 키 접두사
+  private String REDIS_QR_PREFIX = "qrStore:";
+
+  @Transactional(readOnly = false)
+  public StampResponseDto.StampSaveDto save(String qrCode) {
+
+    // key = REDIS_QR_PREFIX(접두사) + qrCode
+    String qrStoreKey = REDIS_QR_PREFIX + qrCode;
+
+    // QR 정보로 Redis 이용하여 가게 ID 조회하기
+    Long storeId = Optional.ofNullable(stringRedisTemplate.opsForValue().get(qrStoreKey))
+        .filter(value -> value.matches("\\d+"))
+        .map(Long::parseLong)
+        .orElseThrow(() -> new QrHandler(ErrorStatus.QR_EXPIRED));
+
+
+    // storeId로 가게 조회하기
+    Store store = storeRepository.findById(storeId)
+        .orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_NOT_FOUND));
+    log.info("storeId = {}", storeId);
+
+    // 스탬프 조회. 없으면 새로 생성
+    User user = authService.getCurrentUser();
+    Stamp stamp = stampRepository.findByUserAndStore(user, store)
+        .orElse(makeStamp(user, store));
+
+    // 스탬프 적립
+    stamp.saveStamp();
+    stampRepository.save(stamp);
+    log.info("스탬프를 적립했습니다. 현재 스탬프 점수 = {}개", stamp.getCount());
+
+    // 스탬프 다 채우면
+    boolean isComplete = stamp.getCount() == Stamp.maxCount;
+    if (isComplete) { // Stamp 클래스에 max 지정되어 있음
+      log.info("스탬프 완성! 쿠폰을 1개 발급했습니다.");
+      stampRepository.delete(stamp); // 스탬프 제거
+      couponRepository.save(makeCoupon(user, store)); // 쿠폰 발급
+    }
+
+    return StampResponseDto.StampSaveDto.builder()
+        .hasEarnedCoupon(isComplete)
+        .build();
+  }
+
+  private Stamp makeStamp(User user, Store store) {
+    return Stamp.builder()
+        .user(user)
+        .store(store)
+        .count(1)
+        .build();
+  }
+
+  private Coupon makeCoupon(User user, Store store) {
+    return Coupon.builder()
+        .name(CouponName.SERVICE.getName())
+        .description(store.getName())
+        .discountAmount(0) // v1 까지는 0으로 두고 v2 이후에 수정
+        .status(CouponStatus.UNUSED)
+        .qrCode(QrCodeType.COUPON.getQrPrefix() + UUID.randomUUID())
+        .user(user)
+        .store(store)
+        .build();
+  }
+
+}

--- a/src/main/java/kkukmoa/kkukmoa/store/repository/StoreRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/store/repository/StoreRepository.java
@@ -11,4 +11,6 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     Optional<Store> findByMerchantNumber(String merchantNumber);
 
     Optional<Store> findByOwner(User owner);
+
+
 }


### PR DESCRIPTION
## 📌 작업 개요
사장님이 보여준 QR 코드로 스탬프 적립하는 API

## 🛠 주요 변경 사항
- Stamp 관련 전이 옵션 제거 ( 안 할 시, User&Store 데이터 삭제됨 )
- 기존 데이터 없을 시, Stamp 데이터 새로 생성
- 스탬프 10개 적립 시, 해당 스탬프 제거 및 쿠폰 데이터 하나 생성
- 고려한 예외 케이스
  - redis에 qr 정보에 맞는 키 값이 없을 때 혹은 만료되었을 때
  - qr 정보로 찾은 store가 존재하지 않을 때

## ✅ 테스트 내역
- [x] Swagger 또는 Postman으로 API 테스트 완료
- [x] DB 저장 / 조회 정상 동작 확인
- [x] 기존 기능과 충돌 없음 확인
- [ ] 예외 케이스 (에러 응답 등) 테스트

## ⚠️ 영향도 및 주의사항
- Store 관련 연관관계 옵션 수정하였습니다.

## 📸 스크린샷 / API 캡처
<img width="980" height="945" alt="image" src="https://github.com/user-attachments/assets/7dc9d281-e449-43ba-9930-83cdd92a4278" />


## 💬 기타 참고 사항
예외 케이스 더 있으면 알려주세요
