### PR TITLE
[FEAT][junyong]: 스탬프 & 쿠폰 API 구현 및 기존 기능 리팩토링

### DIFF
--- a/src/main/java/kkukmoa/kkukmoa/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kkukmoa/kkukmoa/apiPayload/code/status/ErrorStatus.java
@@ -59,7 +59,8 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_PAYMENT_REQUEST(HttpStatus.BAD_REQUEST, "PAYMENT4005", "유효하지 않은 결제 승인 요청입니다."),
 
     // 가게 관련 에러
-    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE4001", "존재하지 않는 가게입니다.")
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE4001", "존재하지 않는 가게입니다."),
+    STORE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE4002", "존재하지 않는 가게 카테고리입니다."),
 
     ;
     private final HttpStatus httpStatus;

--- a/src/main/java/kkukmoa/kkukmoa/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kkukmoa/kkukmoa/apiPayload/code/status/ErrorStatus.java
@@ -61,7 +61,6 @@ public enum ErrorStatus implements BaseErrorCode {
     // 가게 관련 에러
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE4001", "존재하지 않는 가게입니다."),
     STORE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE4002", "존재하지 않는 가게 카테고리입니다."),
-
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/kkukmoa/kkukmoa/owner/controller/OwnerController.java
+++ b/src/main/java/kkukmoa/kkukmoa/owner/controller/OwnerController.java
@@ -3,7 +3,9 @@ package kkukmoa.kkukmoa.owner.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
 import kkukmoa.kkukmoa.apiPayload.exception.ApiResponse;
+import kkukmoa.kkukmoa.common.util.swagger.ApiErrorCodeExamples;
 import kkukmoa.kkukmoa.owner.dto.OwnerQrResponseDto;
 import kkukmoa.kkukmoa.owner.dto.OwnerQrResponseDto.QrScanDto;
 import kkukmoa.kkukmoa.owner.service.OwnerCommandService;
@@ -30,11 +32,20 @@ public class OwnerController {
     @Operation(
             summary = "( 사장님 ) 고객 QR 코드 인식 후 처리 API",
             description =
-                    "QR 코드 정보를 받아 차감할 금액을 반환합니다. 금액 차감에 성공하면<br>"
-                            + "- 쿠폰의 경우  <b>/v1/stamps/coupons</b> <br>"
-                            + "- 금액권의 경우 <b>/v1/...</b> <br>"
-                            + "으로 redirect 하도록 Web Socket 으로 메시지를 보냅니다.<br><br>"
-                            + "웹소켓 요청 주소는 <b>ws://baseUrl/ws</b> 입니다.")
+                """
+                    QR 코드 정보를 받아 차감할 금액을 반환합니다. 금액 차감에 성공하면\n
+                    - 쿠폰의 경우  <b>/v1/stamps/coupons</b>
+                    - 금액권의 경우 <b>/v1/...</b>
+                    으로 redirect 하도록 Web Socket 으로 메시지를 보냅니다.\n
+                    웹소켓 요청 주소는 <b>ws://baseUrl/ws</b> 입니다.
+                """)
+    @ApiErrorCodeExamples(value = {
+        ErrorStatus.AUTHENTICATION_FAILED,
+        ErrorStatus.COUPON_NOT_FOUND,
+        ErrorStatus.OWNER_INVALID_SCAN,
+        ErrorStatus.COUPON_INVALID_USED_PLACE,
+        ErrorStatus.COUPON_IS_USED
+    })
     public ApiResponse<OwnerQrResponseDto.QrScanDto> updateCouponUse(
             @RequestParam("qr") String qrCode) {
         QrScanDto qrScanDto = ownerCommandService.scanQrCode(qrCode);
@@ -45,8 +56,14 @@ public class OwnerController {
     @Operation(
             summary = "( 사장님 ) 스탬프 적립 QR 코드 발급·조회 API",
             description =
-                    "고객에게 보여줄 스탬프 적립용 QR 코드를 발급 받는 API 입니다.<br>생성한 QR 코드의 유효 시간은 1분입니다. 1분이 지나면 해당"
-                            + " API를 다시 호출하여 새로운 QR 코드를 발급 받으세요.")
+                """
+                    고객에게 보여줄 스탬프 적립용 QR 코드를 발급 받는 API 입니다.\n
+                    생성한 QR 코드의 유효 시간은 1분입니다. 1분이 지나면 해당 API를 다시 호출하여 새로운 QR 코드를 발급 받으세요.
+                """)
+    @ApiErrorCodeExamples(value = {
+        ErrorStatus.AUTHENTICATION_FAILED,
+        ErrorStatus.OWNER_STORE_NOT_FOUND
+    })
     public ApiResponse<OwnerQrResponseDto.QrDto> getStampQrCode() {
         OwnerQrResponseDto.QrDto stamp = ownerQueryService.getStamp();
         return ApiResponse.onSuccess(stamp);

--- a/src/main/java/kkukmoa/kkukmoa/owner/controller/OwnerController.java
+++ b/src/main/java/kkukmoa/kkukmoa/owner/controller/OwnerController.java
@@ -32,20 +32,21 @@ public class OwnerController {
     @Operation(
             summary = "( 사장님 ) 고객 QR 코드 인식 후 처리 API",
             description =
-                """
-                    QR 코드 정보를 받아 차감할 금액을 반환합니다. 금액 차감에 성공하면\n
-                    - 쿠폰의 경우  <b>/v1/stamps/coupons</b>
-                    - 금액권의 경우 <b>/v1/...</b>
-                    으로 redirect 하도록 Web Socket 으로 메시지를 보냅니다.\n
-                    웹소켓 요청 주소는 <b>ws://baseUrl/ws</b> 입니다.
-                """)
-    @ApiErrorCodeExamples(value = {
-        ErrorStatus.AUTHENTICATION_FAILED,
-        ErrorStatus.COUPON_NOT_FOUND,
-        ErrorStatus.OWNER_INVALID_SCAN,
-        ErrorStatus.COUPON_INVALID_USED_PLACE,
-        ErrorStatus.COUPON_IS_USED
-    })
+                    """
+                        QR 코드 정보를 받아 차감할 금액을 반환합니다. 금액 차감에 성공하면\n
+                        - 쿠폰의 경우  <b>/v1/stamps/coupons</b>
+                        - 금액권의 경우 <b>/v1/...</b>
+                        으로 redirect 하도록 Web Socket 으로 메시지를 보냅니다.\n
+                        웹소켓 요청 주소는 <b>ws://baseUrl/ws</b> 입니다.
+                    """)
+    @ApiErrorCodeExamples(
+            value = {
+                ErrorStatus.AUTHENTICATION_FAILED,
+                ErrorStatus.COUPON_NOT_FOUND,
+                ErrorStatus.OWNER_INVALID_SCAN,
+                ErrorStatus.COUPON_INVALID_USED_PLACE,
+                ErrorStatus.COUPON_IS_USED
+            })
     public ApiResponse<OwnerQrResponseDto.QrScanDto> updateCouponUse(
             @RequestParam("qr") String qrCode) {
         QrScanDto qrScanDto = ownerCommandService.scanQrCode(qrCode);
@@ -56,14 +57,12 @@ public class OwnerController {
     @Operation(
             summary = "( 사장님 ) 스탬프 적립 QR 코드 발급·조회 API",
             description =
-                """
-                    고객에게 보여줄 스탬프 적립용 QR 코드를 발급 받는 API 입니다.\n
-                    생성한 QR 코드의 유효 시간은 1분입니다. 1분이 지나면 해당 API를 다시 호출하여 새로운 QR 코드를 발급 받으세요.
-                """)
-    @ApiErrorCodeExamples(value = {
-        ErrorStatus.AUTHENTICATION_FAILED,
-        ErrorStatus.OWNER_STORE_NOT_FOUND
-    })
+                    """
+                        고객에게 보여줄 스탬프 적립용 QR 코드를 발급 받는 API 입니다.\n
+                        생성한 QR 코드의 유효 시간은 1분입니다. 1분이 지나면 해당 API를 다시 호출하여 새로운 QR 코드를 발급 받으세요.
+                    """)
+    @ApiErrorCodeExamples(
+            value = {ErrorStatus.AUTHENTICATION_FAILED, ErrorStatus.OWNER_STORE_NOT_FOUND})
     public ApiResponse<OwnerQrResponseDto.QrDto> getStampQrCode() {
         OwnerQrResponseDto.QrDto stamp = ownerQueryService.getStamp();
         return ApiResponse.onSuccess(stamp);

--- a/src/main/java/kkukmoa/kkukmoa/stamp/controller/StampController.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/controller/StampController.java
@@ -3,7 +3,9 @@ package kkukmoa.kkukmoa.stamp.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
 import kkukmoa.kkukmoa.apiPayload.exception.ApiResponse;
+import kkukmoa.kkukmoa.common.util.swagger.ApiErrorCodeExamples;
 import kkukmoa.kkukmoa.stamp.domain.Coupon;
 import kkukmoa.kkukmoa.stamp.dto.couponDto.CouponResponseDto;
 import kkukmoa.kkukmoa.stamp.dto.couponDto.CouponResponseDto.couponListDto;
@@ -35,10 +37,14 @@ public class StampController {
     private final CouponCommandService couponCommandService;
 
     @GetMapping("/")
-    @Operation(summary = "스탬프 목록 조회 API", description = "스탬프 타입을 입력하세요. 페이징 X")
+    @Operation(summary = "스탬프 목록 조회 API", description = "스탬프 타입을 입력하세요.")
+    @ApiErrorCodeExamples(value = {
+        ErrorStatus.STORE_CATEGORY_NOT_FOUND,
+        ErrorStatus.AUTHENTICATION_FAILED
+    })
     public ApiResponse<StampResponseDto.StampListDto> stamps(
             @RequestParam(name = "store-type") String storeType) {
-        StampListDto stampList = stampQueryService.stamList(storeType);
+        StampListDto stampList = stampQueryService.stampList(storeType);
         return ApiResponse.onSuccess(stampList);
     }
 
@@ -46,6 +52,10 @@ public class StampController {
     @Operation(
             summary = "내 쿠폰 목록 조회 API",
             description = "내가 소유한 쿠폰의 목록을 반환합니다.\n쿠폰의 QR코드는 Base64로 형태로 인코딩 되어있습니다.")
+    @ApiErrorCodeExamples(value = {
+        ErrorStatus.AUTHENTICATION_FAILED,
+        ErrorStatus.STORE_CATEGORY_NOT_FOUND
+    })
     public ApiResponse<CouponResponseDto.couponListDto> coupons(
             @RequestParam(name = "store-type") String storeType) {
         couponListDto couponListDto = couponQueryService.couponList(storeType);
@@ -54,12 +64,20 @@ public class StampController {
 
     @GetMapping("/coupons/make")
     @Operation(summary = "테스트용 쿠폰 생성 API", description = "테스트용 쿠폰 생성 API")
+    @ApiErrorCodeExamples({
+
+    })
     public ResponseEntity<Coupon> makeCoupon() {
         return ResponseEntity.ok(couponCommandService.saveCoupon());
     }
 
     @PutMapping("/coupons")
     @Operation(summary = "스탬프 적립 API", description = "QR 코드 정보를 이용하여 스탬프를 적립합니다.<br>스탬프가 10개 적립되면 쿠폰을 발급합니다.")
+    @ApiErrorCodeExamples({
+        ErrorStatus.QR_EXPIRED,
+        ErrorStatus.STORE_NOT_FOUND,
+        ErrorStatus.AUTHENTICATION_FAILED
+    })
     public ApiResponse<StampResponseDto.StampSaveDto> saveCoupon(@RequestParam("qr") String qrCode) {
         StampResponseDto.StampSaveDto saveDto = stampCommandService.save(qrCode);
         return ApiResponse.onSuccess(saveDto);

--- a/src/main/java/kkukmoa/kkukmoa/stamp/controller/StampController.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/controller/StampController.java
@@ -38,10 +38,8 @@ public class StampController {
 
     @GetMapping("/")
     @Operation(summary = "스탬프 목록 조회 API", description = "스탬프 타입을 입력하세요.")
-    @ApiErrorCodeExamples(value = {
-        ErrorStatus.STORE_CATEGORY_NOT_FOUND,
-        ErrorStatus.AUTHENTICATION_FAILED
-    })
+    @ApiErrorCodeExamples(
+            value = {ErrorStatus.STORE_CATEGORY_NOT_FOUND, ErrorStatus.AUTHENTICATION_FAILED})
     public ApiResponse<StampResponseDto.StampListDto> stamps(
             @RequestParam(name = "store-type") String storeType) {
         StampListDto stampList = stampQueryService.stampList(storeType);
@@ -52,10 +50,8 @@ public class StampController {
     @Operation(
             summary = "내 쿠폰 목록 조회 API",
             description = "내가 소유한 쿠폰의 목록을 반환합니다.\n쿠폰의 QR코드는 Base64로 형태로 인코딩 되어있습니다.")
-    @ApiErrorCodeExamples(value = {
-        ErrorStatus.AUTHENTICATION_FAILED,
-        ErrorStatus.STORE_CATEGORY_NOT_FOUND
-    })
+    @ApiErrorCodeExamples(
+            value = {ErrorStatus.AUTHENTICATION_FAILED, ErrorStatus.STORE_CATEGORY_NOT_FOUND})
     public ApiResponse<CouponResponseDto.couponListDto> coupons(
             @RequestParam(name = "store-type") String storeType) {
         couponListDto couponListDto = couponQueryService.couponList(storeType);
@@ -64,25 +60,23 @@ public class StampController {
 
     @GetMapping("/coupons/make")
     @Operation(summary = "테스트용 쿠폰 생성 API", description = "테스트용 쿠폰 생성 API")
-    @ApiErrorCodeExamples({
-
-    })
+    @ApiErrorCodeExamples({})
     public ResponseEntity<Coupon> makeCoupon() {
         return ResponseEntity.ok(couponCommandService.saveCoupon());
     }
 
     @PutMapping("/coupons")
     @Operation(
-        summary = "스탬프 적립 API",
-        description = "QR 코드 정보를 이용하여 스탬프를 적립합니다.<br>스탬프가 10개 적립되면 쿠폰을 발급합니다.")
+            summary = "스탬프 적립 API",
+            description = "QR 코드 정보를 이용하여 스탬프를 적립합니다.<br>스탬프가 10개 적립되면 쿠폰을 발급합니다.")
     @ApiErrorCodeExamples({
         ErrorStatus.QR_EXPIRED,
         ErrorStatus.STORE_NOT_FOUND,
         ErrorStatus.AUTHENTICATION_FAILED
     })
-    public ApiResponse<StampResponseDto.StampSaveDto> saveCoupon(@RequestParam("qr") String qrCode) {
+    public ApiResponse<StampResponseDto.StampSaveDto> saveCoupon(
+            @RequestParam("qr") String qrCode) {
         StampResponseDto.StampSaveDto saveDto = stampCommandService.save(qrCode);
         return ApiResponse.onSuccess(saveDto);
     }
-
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/converter/CouponConverter.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/converter/CouponConverter.java
@@ -14,16 +14,16 @@ public class CouponConverter {
                 .builder()
                 .couponId(coupon.getId())
                 .storeId(store.getId())
-                .storeImg("imgURL")
-                .storeName("storeName")
-                .storeType("storeType")
+                .storeImg(store.getStoreImage())
+                .storeName(store.getName())
+                .storeType(store.getCategory().getName())
                 .couponName(coupon.getName())
                 .couponQrCode(QrCodeUtil.qrCodeToBase64(coupon.getQrCode()))
                 .build();
     }
 
     public static List<CouponResponseDto.couponDto> toCouponDtoList(
-            List<Coupon> coupons, Store store) {
-        return coupons.stream().map(coupon -> CouponConverter.toCouponDto(coupon, store)).toList();
+            List<Coupon> coupons) {
+        return coupons.stream().map(coupon -> CouponConverter.toCouponDto(coupon, coupon.getStore())).toList();
     }
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/converter/CouponConverter.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/converter/CouponConverter.java
@@ -22,8 +22,9 @@ public class CouponConverter {
                 .build();
     }
 
-    public static List<CouponResponseDto.couponDto> toCouponDtoList(
-            List<Coupon> coupons) {
-        return coupons.stream().map(coupon -> CouponConverter.toCouponDto(coupon, coupon.getStore())).toList();
+    public static List<CouponResponseDto.couponDto> toCouponDtoList(List<Coupon> coupons) {
+        return coupons.stream()
+                .map(coupon -> CouponConverter.toCouponDto(coupon, coupon.getStore()))
+                .toList();
     }
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/converter/StampConverter.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/converter/StampConverter.java
@@ -11,13 +11,14 @@ public class StampConverter {
     public static StampResponseDto.StampDto toStampDto(Stamp stamp, Store store) {
         return StampResponseDto.StampDto.builder()
                 .id(stamp.getId())
-                .storeName("준용카페")
+                .storeName(store.getName())
                 .stampScore(stamp.getCount())
                 .build();
     }
 
     public static List<StampResponseDto.StampDto> toStampDtoList(
-            List<Stamp> stampList, Store store) {
-        return stampList.stream().map(stamp -> StampConverter.toStampDto(stamp, store)).toList();
+            List<Stamp> stampList) {
+        System.out.println("hello");
+        return stampList.stream().map(stamp -> StampConverter.toStampDto(stamp, stamp.getStore())).toList();
     }
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/converter/StampConverter.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/converter/StampConverter.java
@@ -16,9 +16,10 @@ public class StampConverter {
                 .build();
     }
 
-    public static List<StampResponseDto.StampDto> toStampDtoList(
-            List<Stamp> stampList) {
+    public static List<StampResponseDto.StampDto> toStampDtoList(List<Stamp> stampList) {
         System.out.println("hello");
-        return stampList.stream().map(stamp -> StampConverter.toStampDto(stamp, stamp.getStore())).toList();
+        return stampList.stream()
+                .map(stamp -> StampConverter.toStampDto(stamp, stamp.getStore()))
+                .toList();
     }
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/domain/Coupon.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/domain/Coupon.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
+import kkukmoa.kkukmoa.common.BaseEntity;
 import kkukmoa.kkukmoa.stamp.enums.CouponStatus;
 import kkukmoa.kkukmoa.store.domain.Store;
 import kkukmoa.kkukmoa.user.domain.User;
@@ -26,7 +27,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Coupon {
+public class Coupon extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kkukmoa/kkukmoa/stamp/domain/Stamp.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/domain/Stamp.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
+import kkukmoa.kkukmoa.common.BaseEntity;
 import kkukmoa.kkukmoa.store.domain.Store;
 import kkukmoa.kkukmoa.user.domain.User;
 
@@ -25,7 +26,7 @@ import org.hibernate.annotations.ColumnDefault;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Stamp {
+public class Stamp extends BaseEntity {
 
     public static int maxCount = 10;
 

--- a/src/main/java/kkukmoa/kkukmoa/stamp/dto/stampDto/StampResponseDto.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/dto/stampDto/StampResponseDto.java
@@ -26,12 +26,15 @@ public class StampResponseDto {
     @Getter
     @Schema(description = "단일 스탬프 정보 DTO")
     public static class StampDto {
+        @JsonProperty(value = "id")
         @Schema(description = "스탬프 식별자", example = "1")
         Long id;
 
+        @JsonProperty(value = "store_name")
         @Schema(description = "가게명", example = "미진카페")
         String storeName;
 
+        @JsonProperty(value = "stamp_score")
         @Schema(description = "스탬프 점수", example = "8")
         Integer stampScore;
     }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/repository/CouponRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/repository/CouponRepository.java
@@ -3,8 +3,8 @@ package kkukmoa.kkukmoa.stamp.repository;
 import kkukmoa.kkukmoa.category.domain.Category;
 import kkukmoa.kkukmoa.stamp.domain.Coupon;
 import kkukmoa.kkukmoa.store.domain.Store;
-
 import kkukmoa.kkukmoa.user.domain.User;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,13 +25,12 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     Optional<Coupon> findByQrFetchUserAndStore(@Param("qrcode") String qrcode);
 
     @Query(
-        """
-          SELECT c FROM Coupon c
-          JOIN FETCH Store s ON c.store = s
-          JOIN FETCH User u ON c.user = :user
-          WHERE c.user = u AND s.category = :category AND c.status = kkukmoa.kkukmoa.stamp.enums.CouponStatus.UNUSED
-        """
-    )
-    List<Coupon> findByCategoryAndUser(@Param("category") Category category, @Param("user") User user);
-
+            """
+              SELECT c FROM Coupon c
+              JOIN FETCH Store s ON c.store = s
+              JOIN FETCH User u ON c.user = :user
+              WHERE c.user = u AND s.category = :category AND c.status = kkukmoa.kkukmoa.stamp.enums.CouponStatus.UNUSED
+            """)
+    List<Coupon> findByCategoryAndUser(
+            @Param("category") Category category, @Param("user") User user);
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/repository/CouponRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/repository/CouponRepository.java
@@ -1,8 +1,10 @@
 package kkukmoa.kkukmoa.stamp.repository;
 
+import kkukmoa.kkukmoa.category.domain.Category;
 import kkukmoa.kkukmoa.stamp.domain.Coupon;
 import kkukmoa.kkukmoa.store.domain.Store;
 
+import kkukmoa.kkukmoa.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,4 +23,15 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
                     + "JOIN FETCH s.owner o "
                     + "WHERE c.qrCode = :qrcode")
     Optional<Coupon> findByQrFetchUserAndStore(@Param("qrcode") String qrcode);
+
+    @Query(
+        """
+          SELECT c FROM Coupon c
+          JOIN FETCH Store s ON c.store = s
+          JOIN FETCH User u ON c.user = :user
+          WHERE c.user = u AND s.category = :category AND c.status = kkukmoa.kkukmoa.stamp.enums.CouponStatus.UNUSED
+        """
+    )
+    List<Coupon> findByCategoryAndUser(@Param("category") Category category, @Param("user") User user);
+
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/repository/StampRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/repository/StampRepository.java
@@ -1,38 +1,36 @@
 package kkukmoa.kkukmoa.stamp.repository;
 
-import java.util.Optional;
 import kkukmoa.kkukmoa.category.domain.Category;
 import kkukmoa.kkukmoa.stamp.domain.Stamp;
 import kkukmoa.kkukmoa.store.domain.Store;
 import kkukmoa.kkukmoa.user.domain.User;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface StampRepository extends JpaRepository<Stamp, Long> {
 
     @Query(
-        """
-        SELECT stamp FROM Stamp stamp
-        JOIN FETCH Store store ON store.id = :storeId AND stamp.store = store
-        WHERE stamp.user = :user
-        """
-    )
+            """
+            SELECT stamp FROM Stamp stamp
+            JOIN FETCH Store store ON store.id = :storeId AND stamp.store = store
+            WHERE stamp.user = :user
+            """)
     Optional<Stamp> findByUserAndStore(@Param("user") User user, @Param("storeId") Long storeId);
 
     Optional<Stamp> findByUserAndStore(User user, Store store);
 
     @Query(
-        """
-          SELECT p, s, u FROM Stamp p
-          JOIN FETCH Store s ON p.store = s
-          JOIN FETCH User u ON p.user = :user
-          WHERE p.user = u AND s.category = :category
-        """
-    )
-    List<Stamp> findByCategoryAndUser(@Param("category") Category category, @Param("user") User user);
-
+            """
+              SELECT p, s, u FROM Stamp p
+              JOIN FETCH Store s ON p.store = s
+              JOIN FETCH User u ON p.user = :user
+              WHERE p.user = u AND s.category = :category
+            """)
+    List<Stamp> findByCategoryAndUser(
+            @Param("category") Category category, @Param("user") User user);
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/repository/StampRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/repository/StampRepository.java
@@ -1,6 +1,7 @@
 package kkukmoa.kkukmoa.stamp.repository;
 
 import java.util.Optional;
+import kkukmoa.kkukmoa.category.domain.Category;
 import kkukmoa.kkukmoa.stamp.domain.Stamp;
 import kkukmoa.kkukmoa.store.domain.Store;
 
@@ -8,10 +9,21 @@ import kkukmoa.kkukmoa.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StampRepository extends JpaRepository<Stamp, Long> {
 
-    List<Stamp> findByStore(Store store);
-
     Optional<Stamp> findByUserAndStore(User user, Store store);
+
+    @Query(
+        """
+          SELECT p, s, u FROM Stamp p
+          JOIN FETCH Store s ON p.store = s
+          JOIN FETCH User u ON p.user = :user
+          WHERE p.user = u AND s.category = :category
+        """
+    )
+    List<Stamp> findByCategoryAndUser(@Param("category") Category category, @Param("user") User user);
+
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/repository/StampRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/repository/StampRepository.java
@@ -14,6 +14,15 @@ import org.springframework.data.repository.query.Param;
 
 public interface StampRepository extends JpaRepository<Stamp, Long> {
 
+    @Query(
+        """
+        SELECT stamp FROM Stamp stamp
+        JOIN FETCH Store store ON store.id = :storeId AND stamp.store = store
+        WHERE stamp.user = :user
+        """
+    )
+    Optional<Stamp> findByUserAndStore(@Param("user") User user, @Param("storeId") Long storeId);
+
     Optional<Stamp> findByUserAndStore(User user, Store store);
 
     @Query(

--- a/src/main/java/kkukmoa/kkukmoa/stamp/service/coupon/CouponQueryService.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/service/coupon/CouponQueryService.java
@@ -10,8 +10,8 @@ import kkukmoa.kkukmoa.stamp.dto.couponDto.CouponResponseDto;
 import kkukmoa.kkukmoa.stamp.dto.couponDto.CouponResponseDto.couponDto;
 import kkukmoa.kkukmoa.stamp.repository.CouponRepository;
 import kkukmoa.kkukmoa.store.repository.CategoryRepository;
-
 import kkukmoa.kkukmoa.user.domain.User;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -34,8 +34,10 @@ public class CouponQueryService {
         User user = authService.getCurrentUser();
 
         // 요청 받은 카테고리 예외 처리
-        Category category = categoryRepository.findByName(storeType)
-            .orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_CATEGORY_NOT_FOUND));
+        Category category =
+                categoryRepository
+                        .findByName(storeType)
+                        .orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_CATEGORY_NOT_FOUND));
 
         // 쿠폰 조회
         List<Coupon> couponList = couponRepository.findByCategoryAndUser(category, user);
@@ -44,7 +46,8 @@ public class CouponQueryService {
         List<couponDto> couponDtoList = CouponConverter.toCouponDtoList(couponList);
 
         // List<dto> -> 응답 형태로 변환 후 반환
-        return CouponResponseDto.couponListDto.builder()
+        return CouponResponseDto.couponListDto
+                .builder()
                 .coupons(couponDtoList)
                 .total(couponList.size())
                 .build();

--- a/src/main/java/kkukmoa/kkukmoa/stamp/service/coupon/CouponQueryService.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/service/coupon/CouponQueryService.java
@@ -1,13 +1,17 @@
 package kkukmoa.kkukmoa.stamp.service.coupon;
 
+import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
+import kkukmoa.kkukmoa.apiPayload.exception.handler.StoreHandler;
+import kkukmoa.kkukmoa.category.domain.Category;
+import kkukmoa.kkukmoa.common.util.AuthService;
 import kkukmoa.kkukmoa.stamp.converter.CouponConverter;
 import kkukmoa.kkukmoa.stamp.domain.Coupon;
 import kkukmoa.kkukmoa.stamp.dto.couponDto.CouponResponseDto;
 import kkukmoa.kkukmoa.stamp.dto.couponDto.CouponResponseDto.couponDto;
 import kkukmoa.kkukmoa.stamp.repository.CouponRepository;
-import kkukmoa.kkukmoa.store.domain.Store;
-import kkukmoa.kkukmoa.store.repository.StoreRepository;
+import kkukmoa.kkukmoa.store.repository.CategoryRepository;
 
+import kkukmoa.kkukmoa.user.domain.User;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -19,23 +23,28 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CouponQueryService {
 
+    private final CategoryRepository categoryRepository;
     private final CouponRepository couponRepository;
-    private final StoreRepository storeRepository;
+    private final AuthService authService;
 
     @Transactional(readOnly = true)
     public CouponResponseDto.couponListDto couponList(String storeType) {
 
-        //    Store store = storeRepository.findByType(storeType);
-        // 우선 하드코딩. store 부분 깃헙에 올라오면 수정
-        Store store = storeRepository.findById(1L).orElse(null);
-        List<Coupon> couponList = couponRepository.findByStore(store);
+        // 로그인한 유저
+        User user = authService.getCurrentUser();
+
+        // 요청 받은 카테고리 예외 처리
+        Category category = categoryRepository.findByName(storeType)
+            .orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_CATEGORY_NOT_FOUND));
+
+        // 쿠폰 조회
+        List<Coupon> couponList = couponRepository.findByCategoryAndUser(category, user);
 
         // dto -> List<dto>로 변환
-        List<couponDto> couponDtoList = CouponConverter.toCouponDtoList(couponList, store);
+        List<couponDto> couponDtoList = CouponConverter.toCouponDtoList(couponList);
 
         // List<dto> -> 응답 형태로 변환 후 반환
-        return CouponResponseDto.couponListDto
-                .builder()
+        return CouponResponseDto.couponListDto.builder()
                 .coupons(couponDtoList)
                 .total(couponList.size())
                 .build();

--- a/src/main/java/kkukmoa/kkukmoa/stamp/service/stamp/StampCommandService.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/service/stamp/StampCommandService.java
@@ -62,12 +62,14 @@ public class StampCommandService {
         Store store;
 
         // 스탬프 유무에 따른 처리
-        if(optionalStamp.isPresent()) { // 스탬프가 존재하면
+        if (optionalStamp.isPresent()) { // 스탬프가 존재하면
             stamp = optionalStamp.get();
             store = stamp.getStore();
         } else { // 스탬프가 존재하지 않으면
-            store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new QrHandler(ErrorStatus.STORE_NOT_FOUND));
+            store =
+                    storeRepository
+                            .findById(storeId)
+                            .orElseThrow(() -> new QrHandler(ErrorStatus.STORE_NOT_FOUND));
             stamp = makeStamp(user, store);
         }
 

--- a/src/main/java/kkukmoa/kkukmoa/stamp/service/stamp/StampQueryService.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/service/stamp/StampQueryService.java
@@ -1,14 +1,18 @@
 package kkukmoa.kkukmoa.stamp.service.stamp;
 
+import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
+import kkukmoa.kkukmoa.apiPayload.exception.handler.StoreHandler;
+import kkukmoa.kkukmoa.category.domain.Category;
+import kkukmoa.kkukmoa.common.util.AuthService;
 import kkukmoa.kkukmoa.stamp.converter.StampConverter;
 import kkukmoa.kkukmoa.stamp.domain.Stamp;
 import kkukmoa.kkukmoa.stamp.dto.stampDto.StampResponseDto;
 import kkukmoa.kkukmoa.stamp.dto.stampDto.StampResponseDto.StampDto;
 import kkukmoa.kkukmoa.stamp.dto.stampDto.StampResponseDto.StampListDto;
 import kkukmoa.kkukmoa.stamp.repository.StampRepository;
-import kkukmoa.kkukmoa.store.domain.Store;
-import kkukmoa.kkukmoa.store.repository.StoreRepository;
+import kkukmoa.kkukmoa.store.repository.CategoryRepository;
 
+import kkukmoa.kkukmoa.user.domain.User;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -21,20 +25,29 @@ import java.util.List;
 public class StampQueryService {
 
     private final StampRepository stampRepository;
-    private final StoreRepository storeRepository;
+    private final CategoryRepository categoryRepository;
+    private final AuthService authService;
 
     @Transactional(readOnly = true)
-    public StampResponseDto.StampListDto stamList(String storeType) {
+    public StampResponseDto.StampListDto stampList(String storeType) {
 
-        //    Store store = storeRepository.findByType(storeType);
-        // 우선 하드코딩. store 부분 깃헙에 올라오면 수정
-        Store store = storeRepository.findById(1L).orElse(null);
-        List<Stamp> stampList = stampRepository.findByStore(store);
+        // 로그인한 유저
+        User user = authService.getCurrentUser();
+
+        // 요청 받은 카테고리 예외 처리
+        Category category = categoryRepository.findByName(storeType)
+            .orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_CATEGORY_NOT_FOUND));
+
+        // 스탬프 조회 ( 가게, 카테고리 fetch join )
+        List<Stamp> stampList = stampRepository.findByCategoryAndUser(category, user);
 
         // dto -> List<dto>로 변환
-        List<StampDto> stampListDto = StampConverter.toStampDtoList(stampList, store);
+        List<StampDto> stampListDto = StampConverter.toStampDtoList(stampList);
 
         // List<dto> -> 응답 형태로 변환 후 반환
-        return StampListDto.builder().stamps(stampListDto).total(stampList.size()).build();
+        return StampListDto.builder()
+            .stamps(stampListDto)
+            .total(stampList.size())
+            .build();
     }
 }

--- a/src/main/java/kkukmoa/kkukmoa/stamp/service/stamp/StampQueryService.java
+++ b/src/main/java/kkukmoa/kkukmoa/stamp/service/stamp/StampQueryService.java
@@ -11,8 +11,8 @@ import kkukmoa.kkukmoa.stamp.dto.stampDto.StampResponseDto.StampDto;
 import kkukmoa.kkukmoa.stamp.dto.stampDto.StampResponseDto.StampListDto;
 import kkukmoa.kkukmoa.stamp.repository.StampRepository;
 import kkukmoa.kkukmoa.store.repository.CategoryRepository;
-
 import kkukmoa.kkukmoa.user.domain.User;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -35,8 +35,10 @@ public class StampQueryService {
         User user = authService.getCurrentUser();
 
         // 요청 받은 카테고리 예외 처리
-        Category category = categoryRepository.findByName(storeType)
-            .orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_CATEGORY_NOT_FOUND));
+        Category category =
+                categoryRepository
+                        .findByName(storeType)
+                        .orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_CATEGORY_NOT_FOUND));
 
         // 스탬프 조회 ( 가게, 카테고리 fetch join )
         List<Stamp> stampList = stampRepository.findByCategoryAndUser(category, user);
@@ -45,9 +47,6 @@ public class StampQueryService {
         List<StampDto> stampListDto = StampConverter.toStampDtoList(stampList);
 
         // List<dto> -> 응답 형태로 변환 후 반환
-        return StampListDto.builder()
-            .stamps(stampListDto)
-            .total(stampList.size())
-            .build();
+        return StampListDto.builder().stamps(stampListDto).total(stampList.size()).build();
     }
 }

--- a/src/main/java/kkukmoa/kkukmoa/store/domain/Store.java
+++ b/src/main/java/kkukmoa/kkukmoa/store/domain/Store.java
@@ -45,7 +45,7 @@ public class Store extends BaseEntity {
     @JoinColumn(name = "category_id")
     private Category category;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User owner;
 }

--- a/src/main/java/kkukmoa/kkukmoa/store/repository/CategoryRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/store/repository/CategoryRepository.java
@@ -1,11 +1,12 @@
 package kkukmoa.kkukmoa.store.repository;
 
-import java.util.Optional;
 import kkukmoa.kkukmoa.category.domain.Category;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-  Optional<Category> findByName(String name);
-
+    Optional<Category> findByName(String name);
 }

--- a/src/main/java/kkukmoa/kkukmoa/store/repository/CategoryRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/store/repository/CategoryRepository.java
@@ -1,0 +1,11 @@
+package kkukmoa.kkukmoa.store.repository;
+
+import java.util.Optional;
+import kkukmoa.kkukmoa.category.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+  Optional<Category> findByName(String name);
+
+}

--- a/src/main/java/kkukmoa/kkukmoa/store/repository/StoreRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/store/repository/StoreRepository.java
@@ -1,5 +1,6 @@
 package kkukmoa.kkukmoa.store.repository;
 
+import kkukmoa.kkukmoa.category.domain.Category;
 import kkukmoa.kkukmoa.store.domain.Store;
 import kkukmoa.kkukmoa.user.domain.User;
 
@@ -12,5 +13,6 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 
     Optional<Store> findByOwner(User owner);
 
+    Optional<Store> findByCategory(Category category);
 
 }

--- a/src/main/java/kkukmoa/kkukmoa/store/repository/StoreRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/store/repository/StoreRepository.java
@@ -5,10 +5,10 @@ import kkukmoa.kkukmoa.store.domain.Store;
 import kkukmoa.kkukmoa.user.domain.User;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
     Optional<Store> findByMerchantNumber(String merchantNumber);
@@ -18,12 +18,10 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     Optional<Store> findByCategory(Category category);
 
     @Query(
-        """
-        SELECT store, stamp FROM Store store
-        JOIN FETCH Stamp stamp ON stamp.store.id = :storeId AND stamp.user = :user
-        WHERE store.id = :storeId
-        """
-    )
+            """
+            SELECT store, stamp FROM Store store
+            JOIN FETCH Stamp stamp ON stamp.store.id = :storeId AND stamp.user = :user
+            WHERE store.id = :storeId
+            """)
     Optional<Store> findStoreAndStamp(@Param("storeId") Long storeId, @Param("user") User user);
-
 }

--- a/src/main/java/kkukmoa/kkukmoa/store/repository/StoreRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/store/repository/StoreRepository.java
@@ -7,6 +7,8 @@ import kkukmoa.kkukmoa.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
     Optional<Store> findByMerchantNumber(String merchantNumber);
@@ -14,5 +16,14 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     Optional<Store> findByOwner(User owner);
 
     Optional<Store> findByCategory(Category category);
+
+    @Query(
+        """
+        SELECT store, stamp FROM Store store
+        JOIN FETCH Stamp stamp ON stamp.store.id = :storeId AND stamp.user = :user
+        WHERE store.id = :storeId
+        """
+    )
+    Optional<Store> findStoreAndStamp(@Param("storeId") Long storeId, @Param("user") User user);
 
 }


### PR DESCRIPTION
## 📌 작업 개요
스탬프 & 쿠폰 관련 구현과 쿼리 관련 리팩토링을 진행했습니다. 

## 🛠 주요 변경 사항
[구현]
- 스탬프를 적립하는 API를 구현했습니다.
- 하드코딩 되어있던 스탬프 목록 & 쿠폰 목록 조회 API를 실제 도메인에 연결하여 구현했습니다.

[리팩토링]
- Store에서 User 조회 시 User 조회 쿼리 한 번 더 나가는 문제를 수정했습니다 -> FetchType Lazy 적용
- 스탬프 적립 시, Stamp와 Store를 한 번에 조회하도록 수정했습니다. -> `StampRepository.findByUserAndStore()` 작성
- 스탬프 적립 시, Store가 존재하지 상황에 대한 예외 처리를 제거했습니다. ( 불필요함 )

[수정]
- 스탬프 생성 시 2개 적립된 상태로 생성되는 문제를 해결헀습니다. -> 객체 처음 생성 시 값 0으로 수정
- 스탬프 제거 시 User와 Store도 같이 없어지는 문제를 해결했습니다.-> Cascade 옵션 제거


## ✅ 테스트 내역
- [x] Swagger 또는 Postman으로 API 테스트 완료
- [x] DB 저장 / 조회 정상 동작 확인
- [x] 기존 기능과 충돌 없음 확인
- [x] 예외 케이스 (에러 응답 등) 테스트

## ⚠️ 영향도 및 주의사항
- 예외 케이스 추가
- Store의 User 필드 속성 수정(FetchType)

## 📸 스크린샷 / API 캡처
| 항목명 | 스크린샷 |
|--------|--------|
| 쿠폰 목록 API | <img width="784" height="693" alt="image" src="https://github.com/user-attachments/assets/4989088d-87b4-4d86-9a93-c323a7bbc8d8" /> |
| 스탬프 목록 API | <img width="493" height="542" alt="image" src="https://github.com/user-attachments/assets/06465868-fc1e-4a70-a46d-1d21512acec4" /> |


## 💬 기타 참고 사항

