### PR TITLE
[FEAT][junyong]: 다양한 요청에 대한 파싱 예외 처리

### DIFF
--- a/src/main/java/kkukmoa/kkukmoa/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/kkukmoa/kkukmoa/apiPayload/exception/ExceptionAdvice.java
@@ -3,7 +3,6 @@ package kkukmoa.kkukmoa.apiPayload.exception;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 
-import java.util.Arrays;
 import kkukmoa.kkukmoa.apiPayload.code.ErrorReasonDto;
 import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
 
@@ -23,6 +22,7 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -48,7 +48,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<Object> handleMethodArgumentTypeMismatch(
-        MethodArgumentTypeMismatchException e, WebRequest request){
+            MethodArgumentTypeMismatchException e, WebRequest request) {
 
         String paramName = e.getName();
         Object invalidValue = e.getValue();
@@ -56,36 +56,41 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
         String errorMessage;
         if (requiredType != null && requiredType.isEnum()) {
-            String enumValues = String.join(", ",
-                Arrays.stream(requiredType.getEnumConstants())
-                    .map(Object::toString)
-                    .toArray(String[]::new));
-            errorMessage = String.format("잘못된 enum 값입니다. [%s=%s], 가능한 값: [%s]",
-                paramName, invalidValue, enumValues);
+            String enumValues =
+                    String.join(
+                            ", ",
+                            Arrays.stream(requiredType.getEnumConstants())
+                                    .map(Object::toString)
+                                    .toArray(String[]::new));
+            errorMessage =
+                    String.format(
+                            "잘못된 enum 값입니다. [%s=%s], 가능한 값: [%s]",
+                            paramName, invalidValue, enumValues);
         } else if (requiredType == Long.class || requiredType == Integer.class) {
             errorMessage = String.format("숫자 타입 파라미터가 잘못되었습니다. [%s=%s]", paramName, invalidValue);
         } else if (requiredType == java.time.LocalDateTime.class) {
-            errorMessage = String.format("날짜/시간 형식이 잘못되었습니다. [%s=%s], 예: 2024-01-01T12:00:00",
-                paramName, invalidValue);
+            errorMessage =
+                    String.format(
+                            "날짜/시간 형식이 잘못되었습니다. [%s=%s], 예: 2024-01-01T12:00:00",
+                            paramName, invalidValue);
         } else if (requiredType == java.time.LocalDate.class) {
-            errorMessage = String.format("날짜 형식이 잘못되었습니다. [%s=%s], 예: 2024-01-01",
-                paramName, invalidValue);
+            errorMessage =
+                    String.format(
+                            "날짜 형식이 잘못되었습니다. [%s=%s], 예: 2024-01-01", paramName, invalidValue);
         } else {
-            errorMessage = String.format("요청 파라미터 타입이 잘못되었습니다. [%s=%s], 기대 타입: %s",
-                paramName, invalidValue, requiredType != null ? requiredType.getSimpleName() : "알 수 없음");
+            errorMessage =
+                    String.format(
+                            "요청 파라미터 타입이 잘못되었습니다. [%s=%s], 기대 타입: %s",
+                            paramName,
+                            invalidValue,
+                            requiredType != null ? requiredType.getSimpleName() : "알 수 없음");
         }
 
         Map<String, String> errorArgs = Map.of(paramName, errorMessage);
 
         return handleExceptionInternalArgs(
-            e,
-            HttpHeaders.EMPTY,
-            ErrorStatus.valueOf("BAD_REQUEST"),
-            request,
-            errorArgs
-        );
+                e, HttpHeaders.EMPTY, ErrorStatus.valueOf("BAD_REQUEST"), request, errorArgs);
     }
-
 
     @Override
     public ResponseEntity<Object> handleMethodArgumentNotValid(

--- a/src/main/java/kkukmoa/kkukmoa/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/kkukmoa/kkukmoa/apiPayload/exception/ExceptionAdvice.java
@@ -3,6 +3,7 @@ package kkukmoa.kkukmoa.apiPayload.exception;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 
+import java.util.Arrays;
 import kkukmoa.kkukmoa.apiPayload.code.ErrorReasonDto;
 import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
 
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.LinkedHashMap;
@@ -43,6 +45,47 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         return handleExceptionInternalConstraint(
                 e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request);
     }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<Object> handleMethodArgumentTypeMismatch(
+        MethodArgumentTypeMismatchException e, WebRequest request){
+
+        String paramName = e.getName();
+        Object invalidValue = e.getValue();
+        Class<?> requiredType = e.getRequiredType();
+
+        String errorMessage;
+        if (requiredType != null && requiredType.isEnum()) {
+            String enumValues = String.join(", ",
+                Arrays.stream(requiredType.getEnumConstants())
+                    .map(Object::toString)
+                    .toArray(String[]::new));
+            errorMessage = String.format("잘못된 enum 값입니다. [%s=%s], 가능한 값: [%s]",
+                paramName, invalidValue, enumValues);
+        } else if (requiredType == Long.class || requiredType == Integer.class) {
+            errorMessage = String.format("숫자 타입 파라미터가 잘못되었습니다. [%s=%s]", paramName, invalidValue);
+        } else if (requiredType == java.time.LocalDateTime.class) {
+            errorMessage = String.format("날짜/시간 형식이 잘못되었습니다. [%s=%s], 예: 2024-01-01T12:00:00",
+                paramName, invalidValue);
+        } else if (requiredType == java.time.LocalDate.class) {
+            errorMessage = String.format("날짜 형식이 잘못되었습니다. [%s=%s], 예: 2024-01-01",
+                paramName, invalidValue);
+        } else {
+            errorMessage = String.format("요청 파라미터 타입이 잘못되었습니다. [%s=%s], 기대 타입: %s",
+                paramName, invalidValue, requiredType != null ? requiredType.getSimpleName() : "알 수 없음");
+        }
+
+        Map<String, String> errorArgs = Map.of(paramName, errorMessage);
+
+        return handleExceptionInternalArgs(
+            e,
+            HttpHeaders.EMPTY,
+            ErrorStatus.valueOf("BAD_REQUEST"),
+            request,
+            errorArgs
+        );
+    }
+
 
     @Override
     public ResponseEntity<Object> handleMethodArgumentNotValid(


### PR DESCRIPTION
## 📌 작업 개요
카카오 로그인 연동 및 JWT 발급 기능 추가

## 🛠 주요 변경 사항
- `ExceptionAdvice`: 타입에 대한 파싱 예외처리 추가

## 🔗 관련 이슈
#59 

## ✅ 테스트 내역
- [x] Swagger 또는 Postman으로 API 테스트 완료
- [x] DB 저장 / 조회 정상 동작 확인
- [x] 기존 기능과 충돌 없음 확인
- [x] 예외 케이스 (에러 응답 등) 테스트

## ⚠️ 영향도 및 주의사항
x

## 📸 스크린샷 / API 캡처
<img width="797" height="261" alt="image" src="https://github.com/user-attachments/assets/f485ff5c-cdd3-4caf-b3ec-4f7bdf9cf4b6" />

## 💬 기타 참고 사항
추후 추가 예정 - 권한, 경로변수 등...
