### PR TITLE
[Refactor][jjaeroong]: 카카오 로그인 토큰 발급 후 리다이렉트 처리 및 응답 방식 변경

### DIFF
--- a/src/main/java/kkukmoa/kkukmoa/user/controller/UserController.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/controller/UserController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.servlet.http.HttpServletResponse;
+
 import kkukmoa.kkukmoa.apiPayload.code.ErrorReasonDto;
 import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
 import kkukmoa.kkukmoa.apiPayload.exception.ApiResponse;
@@ -41,30 +42,30 @@ public class UserController {
                             + "- isNewUser: false (기존 유저, DB 조회 확인됨)\n"
                             + "- isNewUser: true  (신규 유저, DB에 없음)",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "성공적으로 토큰 발급 및 유저 정보 반환",
-                            headers = {
-                                    @Header(
-                                            name = HttpHeaders.AUTHORIZATION,
-                                            description = "JWT access token",
-                                            schema = @Schema(type = "string"))
-                            },
-                            content =
-                            @Content(
-                                    mediaType = "application/json",
-                                    schema =
-                                    @Schema(
-                                            implementation =
-                                                    UserResponseDto.loginDto.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "400",
-                            description = "Invalid Parameter (예: code 누락)",
-                            content = @Content(mediaType = "application/json")),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "Internal Server Error (카카오 API 오류 또는 DB 처리 실패)",
-                            content = @Content(mediaType = "application/json"))
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "성공적으로 토큰 발급 및 유저 정보 반환",
+                        headers = {
+                            @Header(
+                                    name = HttpHeaders.AUTHORIZATION,
+                                    description = "JWT access token",
+                                    schema = @Schema(type = "string"))
+                        },
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                UserResponseDto.loginDto.class))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "Invalid Parameter (예: code 누락)",
+                        content = @Content(mediaType = "application/json")),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "500",
+                        description = "Internal Server Error (카카오 API 오류 또는 DB 처리 실패)",
+                        content = @Content(mediaType = "application/json"))
             })
     public ResponseEntity<ApiResponse<UserResponseDto.loginDto>> callback(
             @RequestParam("code") String code, HttpServletResponse response) throws IOException {
@@ -74,7 +75,7 @@ public class UserController {
 
         // JWT 토큰 발급
         String accessToken = userResponse.getTokenResponseDto().getAccessToken();
-        String refreshToken = userResponse.getTokenResponseDto().getRefreshToken();  // 리프레시 토큰 추가
+        String refreshToken = userResponse.getTokenResponseDto().getRefreshToken(); // 리프레시 토큰 추가
 
         // 리다이렉트 URL 생성 (AccessToken과 RefreshToken을 URL에 포함하지 않음)
         String redirectUri = "kkukmoa://oauth";
@@ -83,7 +84,7 @@ public class UserController {
         response.setHeader("Location", redirectUri);
 
         // 리다이렉트 상태 코드(302) 반환
-        response.setStatus(HttpServletResponse.SC_FOUND);  // 302 상태 코드
+        response.setStatus(HttpServletResponse.SC_FOUND); // 302 상태 코드
 
         // Authorization 헤더에 JWT 토큰 포함
         response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);

--- a/src/main/java/kkukmoa/kkukmoa/user/controller/UserController.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/controller/UserController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.servlet.http.HttpServletResponse;
+
 import kkukmoa.kkukmoa.apiPayload.code.ErrorReasonDto;
 import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
 import kkukmoa.kkukmoa.apiPayload.exception.ApiResponse;
@@ -45,30 +46,30 @@ public class UserController {
                             + "- isNewUser: false (기존 유저, DB 조회 확인됨)\n"
                             + "- isNewUser: true  (신규 유저, DB에 없음)",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "성공적으로 토큰 발급 및 유저 정보 반환",
-                            headers = {
-                                    @Header(
-                                            name = HttpHeaders.AUTHORIZATION,
-                                            description = "JWT access token",
-                                            schema = @Schema(type = "string"))
-                            },
-                            content =
-                            @Content(
-                                    mediaType = "application/json",
-                                    schema =
-                                    @Schema(
-                                            implementation =
-                                                    UserResponseDto.loginDto.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "400",
-                            description = "Invalid Parameter (예: code 누락)",
-                            content = @Content(mediaType = "application/json")),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "Internal Server Error (카카오 API 오류 또는 DB 처리 실패)",
-                            content = @Content(mediaType = "application/json"))
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "성공적으로 토큰 발급 및 유저 정보 반환",
+                        headers = {
+                            @Header(
+                                    name = HttpHeaders.AUTHORIZATION,
+                                    description = "JWT access token",
+                                    schema = @Schema(type = "string"))
+                        },
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                UserResponseDto.loginDto.class))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "Invalid Parameter (예: code 누락)",
+                        content = @Content(mediaType = "application/json")),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "500",
+                        description = "Internal Server Error (카카오 API 오류 또는 DB 처리 실패)",
+                        content = @Content(mediaType = "application/json"))
             })
     public ResponseEntity<ApiResponse<UserResponseDto.loginDto>> callback(
             @RequestParam("code") String code, HttpServletResponse response) throws IOException {
@@ -78,7 +79,8 @@ public class UserController {
 
         // JWT 토큰 발급
         String accessToken = userResponse.getTokenResponseDto().getAccessToken();
-        String encodedToken = UriUtils.encode(accessToken, StandardCharsets.UTF_8); // 토큰을 URL-safe 방식으로 인코딩
+        String encodedToken =
+                UriUtils.encode(accessToken, StandardCharsets.UTF_8); // 토큰을 URL-safe 방식으로 인코딩
 
         // 리다이렉트 URL 생성 (AccessToken을 URL 쿼리 파라미터로 포함)
         String redirectUri = "kkukmoa://oauth?token=" + encodedToken;
@@ -88,7 +90,6 @@ public class UserController {
                 .location(URI.create(redirectUri)) // Location 헤더에 리다이렉트 URL 설정
                 .build();
     }
-
 
     @PostMapping("/logout")
     @Operation(


### PR DESCRIPTION
## 📌 작업 개요
카카오 로그인 연동 및 JWT 발급 기능 추가

## 🛠 주요 변경 사항
- UserCommandService: 카카오 토큰 조회 로직 추가
- JwtProvider: JWT 생성 메서드 구현

## 🔗 관련 이슈
#12

## ✅ 테스트 내역
- [ ] Swagger 또는 Postman으로 API 테스트 완료
- [ ] DB 저장 / 조회 정상 동작 확인
- [ ] 기존 기능과 충돌 없음 확인
- [ ] 예외 케이스 (에러 응답 등) 테스트

## ⚠️ 영향도 및 주의사항
- 로그인 응답 포맷 변경 (프론트 반영 필요)
- 기존 사용자 인증 방식과 충돌 없음

## 📸 스크린샷 / API 캡처
(스크린샷 drag & drop)

## 💬 기타 참고 사항
TODO: 추후 리팩터링 예정
