### PR TITLE
[FIX][mumi]: 가게 조회 API 비로그인 적용

### DIFF
--- a/src/main/java/kkukmoa/kkukmoa/config/security/SecurityConfig.java
+++ b/src/main/java/kkukmoa/kkukmoa/config/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -57,6 +58,7 @@ public class SecurityConfig {
                                                 "/health", // 인프라 상태검사
                                                 "/api/images/**")
                                         .permitAll()
+                                        .requestMatchers(HttpMethod.GET, "/v1/stores/**").permitAll()
                                         .anyRequest()
                                         .authenticated())
                 //                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider,

--- a/src/main/java/kkukmoa/kkukmoa/config/security/SecurityConfig.java
+++ b/src/main/java/kkukmoa/kkukmoa/config/security/SecurityConfig.java
@@ -58,7 +58,8 @@ public class SecurityConfig {
                                                 "/health", // 인프라 상태검사
                                                 "/api/images/**")
                                         .permitAll()
-                                        .requestMatchers(HttpMethod.GET, "/v1/stores/**").permitAll()
+                                        .requestMatchers(HttpMethod.GET, "/v1/stores/**")
+                                        .permitAll()
                                         .anyRequest()
                                         .authenticated())
                 //                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider,


### PR DESCRIPTION
## 📌 작업 개요
가게 조회 API 비로그인 적용

## 🛠 주요 변경 사항
- SecurityConfig에 가게 페이지 비로그인 사용자도 접근 가능하도록 수정

## 🔗 관련 이슈
#91

## ✅ 테스트 내역
- [ ] Swagger 또는 Postman으로 API 테스트 완료
- [ ] DB 저장 / 조회 정상 동작 확인
- [ ] 기존 기능과 충돌 없음 확인
- [ ] 예외 케이스 (에러 응답 등) 테스트

## ⚠️ 영향도 및 주의사항
- 로그인 응답 포맷 변경 (프론트 반영 필요)
- 기존 사용자 인증 방식과 충돌 없음

## 📸 스크린샷 / API 캡처
(스크린샷 drag & drop)

## 💬 기타 참고 사항
TODO: 추후 리팩터링 예정
