### PR TITLE
[Feat][Federico] : 로컬로그인 구현

### DIFF
--- a/src/main/java/kkukmoa/kkukmoa/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kkukmoa/kkukmoa/apiPayload/code/status/ErrorStatus.java
@@ -22,6 +22,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 카카오 API 관련 에러
     KAKAO_API_FAILED(HttpStatus.BAD_GATEWAY, "KAKAO5001", "카카오 API 호출에 실패했습니다."),
     // 사용자 관련 에러
+    DUPLICATION_DUPLICATION_EMAIL(HttpStatus.CONFLICT, "USER4003", "이미 사용 중인 이메일입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4004", "유저를 찾을 수 없습니다."),
     DUPLICATION_PHONE_NUMBER(HttpStatus.CONFLICT, "USER4005", "이미 사용 중인 전화번호입니다."),
     PASSWORD_NOT_MATCH(HttpStatus.UNAUTHORIZED, "USER_401", "비밀번호가 일치하지 않습니다."),

--- a/src/main/java/kkukmoa/kkukmoa/config/security/SecurityConfig.java
+++ b/src/main/java/kkukmoa/kkukmoa/config/security/SecurityConfig.java
@@ -58,6 +58,8 @@ public class SecurityConfig {
                                                 "/v1/users/oauth/kakao",
                                                 "/v1/users/reissue",
                                                 "/v1/users/exchange",
+                                                "/v1/users/signup/local",
+                                                "/v1/users/login/local",
                                                 "/v1/public/registrations/check-pending",
                                                 "/ws/**",
                                                 "/health", // 인프라 상태검사

--- a/src/main/java/kkukmoa/kkukmoa/owner/service/OwnerRegisterService.java
+++ b/src/main/java/kkukmoa/kkukmoa/owner/service/OwnerRegisterService.java
@@ -27,7 +27,6 @@ public class OwnerRegisterService {
     private final CategoryRepository categoryRepository;
     private final RegionService regionService; // ※ Region 로직은 그대로 유지
 
-
     @Transactional
     public void applyStoreRegistration(User user, OwnerRegisterRequest request) {
         /* 1) 중복 신청 방지 정책

--- a/src/main/java/kkukmoa/kkukmoa/user/controller/UserController.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/controller/UserController.java
@@ -8,11 +8,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import jakarta.validation.Valid;
 import kkukmoa.kkukmoa.apiPayload.code.ErrorReasonDto;
 import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
 import kkukmoa.kkukmoa.apiPayload.exception.ApiResponse;
 import kkukmoa.kkukmoa.common.util.swagger.ApiErrorCodeExamples;
 import kkukmoa.kkukmoa.user.domain.User;
+import kkukmoa.kkukmoa.user.dto.LocalLoginRequest;
+import kkukmoa.kkukmoa.user.dto.LocalSignupRequest;
 import kkukmoa.kkukmoa.user.dto.TokenResponseDto;
 import kkukmoa.kkukmoa.user.dto.UserResponseDto;
 import kkukmoa.kkukmoa.user.repository.AuthExchangeRepository;
@@ -166,5 +169,20 @@ public class UserController {
     public ResponseEntity<TokenResponseDto> reissue(HttpServletRequest request) {
         TokenResponseDto tokens = reissueService.reissue(request);
         return ResponseEntity.ok(tokens);
+    }
+
+    @Operation(summary = "로컬 회원가입", description = "이메일/비밀번호로 일반 유저를 생성합니다.")
+    @PostMapping("/signup/local")
+    public ResponseEntity<ApiResponse<String>>
+    signupLocal(@Valid @RequestBody LocalSignupRequest request) {
+        userCommandService.registerLocalUser(request);
+        return ResponseEntity.ok(ApiResponse.onSuccess("유저 회원가입 성공"));
+    }
+
+    @Operation(summary = "로컬 로그인", description = "이메일/비밀번호로 로그인하고 토큰을 발급받습니다.")
+    @PostMapping("/login/local")
+    public ResponseEntity<TokenResponseDto> loginLocal(@Valid @RequestBody LocalLoginRequest request) {
+        TokenResponseDto token = userCommandService.loginLocalUser(request);
+        return ResponseEntity.ok(token);
     }
 }

--- a/src/main/java/kkukmoa/kkukmoa/user/controller/UserController.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/controller/UserController.java
@@ -7,8 +7,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.servlet.http.HttpServletRequest;
-
 import jakarta.validation.Valid;
+
 import kkukmoa.kkukmoa.apiPayload.code.ErrorReasonDto;
 import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
 import kkukmoa.kkukmoa.apiPayload.exception.ApiResponse;
@@ -173,15 +173,16 @@ public class UserController {
 
     @Operation(summary = "로컬 회원가입", description = "이메일/비밀번호로 일반 유저를 생성합니다.")
     @PostMapping("/signup/local")
-    public ResponseEntity<ApiResponse<String>>
-    signupLocal(@Valid @RequestBody LocalSignupRequest request) {
+    public ResponseEntity<ApiResponse<String>> signupLocal(
+            @Valid @RequestBody LocalSignupRequest request) {
         userCommandService.registerLocalUser(request);
         return ResponseEntity.ok(ApiResponse.onSuccess("유저 회원가입 성공"));
     }
 
     @Operation(summary = "로컬 로그인", description = "이메일/비밀번호로 로그인하고 토큰을 발급받습니다.")
     @PostMapping("/login/local")
-    public ResponseEntity<TokenResponseDto> loginLocal(@Valid @RequestBody LocalLoginRequest request) {
+    public ResponseEntity<TokenResponseDto> loginLocal(
+            @Valid @RequestBody LocalLoginRequest request) {
         TokenResponseDto token = userCommandService.loginLocalUser(request);
         return ResponseEntity.ok(token);
     }

--- a/src/main/java/kkukmoa/kkukmoa/user/domain/User.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/domain/User.java
@@ -70,7 +70,6 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "role", length = 30)
     private Set<UserType> roles = new HashSet<>();
 
-
     @Override
     public String getPassword() {
         return String.valueOf(this.password);

--- a/src/main/java/kkukmoa/kkukmoa/user/domain/User.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/domain/User.java
@@ -70,6 +70,7 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "role", length = 30)
     private Set<UserType> roles = new HashSet<>();
 
+
     @Override
     public String getPassword() {
         return String.valueOf(this.password);

--- a/src/main/java/kkukmoa/kkukmoa/user/dto/LocalLoginRequest.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/dto/LocalLoginRequest.java
@@ -1,8 +1,10 @@
 package kkukmoa.kkukmoa.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/kkukmoa/kkukmoa/user/dto/LocalLoginRequest.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/dto/LocalLoginRequest.java
@@ -1,0 +1,21 @@
+package kkukmoa.kkukmoa.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LocalLoginRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @Schema(description = "이메일", example = "demo@kkukmoa.shop")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Schema(description = "비밀번호", example = "passw0rd")
+    private String password;
+}

--- a/src/main/java/kkukmoa/kkukmoa/user/dto/LocalSignupRequest.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/dto/LocalSignupRequest.java
@@ -1,0 +1,23 @@
+package kkukmoa.kkukmoa.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LocalSignupRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @Schema(description = "이메일", example = "demo@kkukmoa.shop")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 6, message = "비밀번호는 최소 6자 이상이어야 합니다.")
+    @Schema(description = "비밀번호(6자 이상)", example = "passw0rd")
+    private String password;
+}

--- a/src/main/java/kkukmoa/kkukmoa/user/dto/LocalSignupRequest.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/dto/LocalSignupRequest.java
@@ -1,9 +1,11 @@
 package kkukmoa.kkukmoa.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/kkukmoa/kkukmoa/user/repository/UserRepository.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/repository/UserRepository.java
@@ -14,5 +14,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByPhoneNumber(String phoneNumber);
 
+    boolean existsByEmail(String email);
+
     Optional<User> findByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/kkukmoa/kkukmoa/user/service/UserCommandService.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/service/UserCommandService.java
@@ -162,7 +162,6 @@ public class UserCommandService {
         log.info("로그아웃 완료 - userId: {}, Access Token 블랙리스트 등록", user.getId());
     }
 
-
     @Transactional
     public void registerLocalUser(LocalSignupRequest request) {
         // 1) 이메일 중복 체크
@@ -171,20 +170,23 @@ public class UserCommandService {
         }
 
         // 2) 사용자 생성 (시연용: 최소 필드만)
-        User user = User.builder()
-                .email(request.getEmail())
-                .password(passwordEncoder.encode(request.getPassword())) // 비밀번호는 반드시 해시
-                .socialType(SocialType.LOCAL)                           // 로컬 가입 표시
-                .roles(Set.of(UserType.USER))                           // 일반 유저 역할
-                .build();
+        User user =
+                User.builder()
+                        .email(request.getEmail())
+                        .password(passwordEncoder.encode(request.getPassword())) // 비밀번호는 반드시 해시
+                        .socialType(SocialType.LOCAL) // 로컬 가입 표시
+                        .roles(Set.of(UserType.USER)) // 일반 유저 역할
+                        .build();
 
         userRepository.save(user);
     }
 
     @Transactional
     public TokenResponseDto loginLocalUser(LocalLoginRequest request) {
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+        User user =
+                userRepository
+                        .findByEmail(request.getEmail())
+                        .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new RuntimeException("비밀번호가 일치하지 않습니다.");
@@ -192,5 +194,4 @@ public class UserCommandService {
 
         return jwtTokenProvider.createToken(user);
     }
-
 }


### PR DESCRIPTION
## 📌 작업 개요
로컬로그인 구현

## 🛠 주요 변경 사항
- UserCommandService: 로컬 로그인, 회원가입 추가

## 🔗 관련 이슈
#109 

## ✅ 테스트 내역
- [ ] Swagger 또는 Postman으로 API 테스트 완료
- [ ] DB 저장 / 조회 정상 동작 확인

## ⚠️ 영향도 및 주의사항
- 로그인 응답 포맷 변경 (프론트 반영 필요)
- 기존 사용자 인증 방식과 충돌 없음

## 📸 스크린샷 / API 캡처
(스크린샷 drag & drop)

## 💬 기타 참고 사항
TODO: 추후 리팩터링 예정
