### PR TITLE
[REFACTOR][junyong]: 웹소켓 인증 수정

### DIFF
--- a/src/main/java/kkukmoa/kkukmoa/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kkukmoa/kkukmoa/apiPayload/code/status/ErrorStatus.java
@@ -106,7 +106,6 @@ public enum ErrorStatus implements BaseErrorCode {
     WEBSOCKET_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "WS4004", "인증 토큰이 필요합니다."),
     WEBSOCKET_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "WS4005", "인증 토큰이 유효하지 않습니다."),
     WEBSOCKET_LOGIN_REQUIRED(HttpStatus.FORBIDDEN, "WS4006", "로그인이 필요합니다."),
-
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kkukmoa/kkukmoa/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kkukmoa/kkukmoa/apiPayload/code/status/ErrorStatus.java
@@ -99,7 +99,14 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 입점 신청 관련 에러
     STORE_REGISTRATION_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE4003", "존재하지 않는 입점 신청입니다."),
-    STORE_ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "STORE4004", "이미 승인된 입점 신청입니다.");
+    STORE_ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "STORE4004", "이미 승인된 입점 신청입니다."),
+
+    // 웹소켓 관련 에러
+    WEBSOCKET_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "WS4004", "인증 토큰이 필요합니다."),
+    WEBSOCKET_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "WS4005", "인증 토큰이 유효하지 않습니다."),
+    WEBSOCKET_LOGIN_REQUIRED(HttpStatus.FORBIDDEN, "WS4006", "로그인이 필요합니다."),
+
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/kkukmoa/kkukmoa/config/security/JwtTokenProvider.java
+++ b/src/main/java/kkukmoa/kkukmoa/config/security/JwtTokenProvider.java
@@ -49,8 +49,8 @@ public class JwtTokenProvider {
     }
 
     public TokenResponseDto createToken(User user) {
-         Claims claims = Jwts.claims().setSubject(user.getEmail());
-//        Claims claims = Jwts.claims().setSubject(String.valueOf(user.getId()));
+        Claims claims = Jwts.claims().setSubject(user.getEmail());
+        //        Claims claims = Jwts.claims().setSubject(String.valueOf(user.getId()));
         Date now = new Date();
 
         String accessToken =
@@ -153,7 +153,7 @@ public class JwtTokenProvider {
 
     public Authentication getAuthentication(String token) {
         String email = getSubjectFromToken(token); // sub에서 email 꺼냄
-//        Long userId = Long.parseLong(userIdString); // sub에서 userId 꺼냄
+        //        Long userId = Long.parseLong(userIdString); // sub에서 userId 꺼냄
 
         // email로 조회
         User user =

--- a/src/main/java/kkukmoa/kkukmoa/config/security/JwtTokenProvider.java
+++ b/src/main/java/kkukmoa/kkukmoa/config/security/JwtTokenProvider.java
@@ -49,8 +49,8 @@ public class JwtTokenProvider {
     }
 
     public TokenResponseDto createToken(User user) {
-        // Claims claims = Jwts.claims().setSubject(user.getEmail());
-        Claims claims = Jwts.claims().setSubject(String.valueOf(user.getId()));
+         Claims claims = Jwts.claims().setSubject(user.getEmail());
+//        Claims claims = Jwts.claims().setSubject(String.valueOf(user.getId()));
         Date now = new Date();
 
         String accessToken =
@@ -151,24 +151,14 @@ public class JwtTokenProvider {
                 .getSubject();
     }
 
-    /*    public Authentication getAuthentication(String token) {
-        String email = getEmailFromToken(token);
+    public Authentication getAuthentication(String token) {
+        String email = getSubjectFromToken(token); // sub에서 email 꺼냄
+//        Long userId = Long.parseLong(userIdString); // sub에서 userId 꺼냄
+
+        // email로 조회
         User user =
                 userRepository
                         .findByEmail(email)
-                        .orElseThrow(
-                                () -> new UserHandler(ErrorStatus.USER_NOT_FOUND)); // 이걸 한 번만 조회
-
-        // 여기서 User를 Principal로 넣는다!
-        return new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
-    }*/
-    public Authentication getAuthentication(String token) {
-        String userIdString = getSubjectFromToken(token); // sub에서 userId 꺼냄
-        Long userId = Long.parseLong(userIdString);
-
-        User user =
-                userRepository
-                        .findById(userId)
                         .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         return new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());

--- a/src/main/java/kkukmoa/kkukmoa/config/websocket/JwtHandshakeInterceptor.java
+++ b/src/main/java/kkukmoa/kkukmoa/config/websocket/JwtHandshakeInterceptor.java
@@ -43,31 +43,33 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
             String email = jwtTokenProvider.getSubjectFromToken(token);
             attributes.put("email", email);
 
-        } else if(token == null){
+        } else if (token == null) {
             throw new GeneralException(ErrorStatus.WEBSOCKET_TOKEN_NOT_FOUND);
-        } else{
+        } else {
             throw new GeneralException(ErrorStatus.WEBSOCKET_TOKEN_INVALID);
         }
 
         // 서버 -> 클라이언트 subprotocol 응답 ( 꼭 필요함... )
-        if(response instanceof ServerHttpResponse) {
-            ((ServletServerHttpResponse) response).getServletResponse().setHeader("Sec-WebSocket-Protocol", token);
+        if (response instanceof ServerHttpResponse) {
+            ((ServletServerHttpResponse) response)
+                    .getServletResponse()
+                    .setHeader("Sec-WebSocket-Protocol", token);
         }
 
         return true;
-//        log.info("[+] JwtHandshakeInterceptor beforeHandshake :: " + request.getURI());
-//        String token = extractToken(request.getHeaders().get("Authorization"));
-//        if (token != null && jwtTokenProvider.validateToken(token)) {
-//            /*            String email = jwtTokenProvider.getEmailFromToken(token);
-//            attributes.put("email", email);*/
-//            String userId = jwtTokenProvider.getSubjectFromToken(token); // sub 값
-//            attributes.put("userId", userId); // 이후 세션에서 사용
-//        } else if(token == null){
-//            throw new GeneralException(ErrorStatus.WEBSOCKET_TOKEN_NOT_FOUND);
-//        } else{
-//            throw new GeneralException(ErrorStatus.WEBSOCKET_TOKEN_INVALID);
-//        }
-//        return true;
+        //        log.info("[+] JwtHandshakeInterceptor beforeHandshake :: " + request.getURI());
+        //        String token = extractToken(request.getHeaders().get("Authorization"));
+        //        if (token != null && jwtTokenProvider.validateToken(token)) {
+        //            /*            String email = jwtTokenProvider.getEmailFromToken(token);
+        //            attributes.put("email", email);*/
+        //            String userId = jwtTokenProvider.getSubjectFromToken(token); // sub 값
+        //            attributes.put("userId", userId); // 이후 세션에서 사용
+        //        } else if(token == null){
+        //            throw new GeneralException(ErrorStatus.WEBSOCKET_TOKEN_NOT_FOUND);
+        //        } else{
+        //            throw new GeneralException(ErrorStatus.WEBSOCKET_TOKEN_INVALID);
+        //        }
+        //        return true;
     }
 
     private String extractToken(List<String> headers) {

--- a/src/main/java/kkukmoa/kkukmoa/config/websocket/JwtHandshakeInterceptor.java
+++ b/src/main/java/kkukmoa/kkukmoa/config/websocket/JwtHandshakeInterceptor.java
@@ -40,8 +40,9 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
         }
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
-            String userId = jwtTokenProvider.getSubjectFromToken(token);
-            attributes.put("userId", userId);
+            String email = jwtTokenProvider.getSubjectFromToken(token);
+            attributes.put("email", email);
+
         } else if(token == null){
             throw new GeneralException(ErrorStatus.WEBSOCKET_TOKEN_NOT_FOUND);
         } else{

--- a/src/main/java/kkukmoa/kkukmoa/config/websocket/handler/QrWebSocketHandler.java
+++ b/src/main/java/kkukmoa/kkukmoa/config/websocket/handler/QrWebSocketHandler.java
@@ -2,6 +2,8 @@ package kkukmoa.kkukmoa.config.websocket.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
+import kkukmoa.kkukmoa.apiPayload.exception.GeneralException;
 import kkukmoa.kkukmoa.owner.dto.QrMessageDto;
 import kkukmoa.kkukmoa.owner.dto.QrMessageDto.QrGeneralTextDto;
 
@@ -46,7 +48,7 @@ public class QrWebSocketHandler extends TextWebSocketHandler {
             emailSessionMap.put(email, session);
             log.info("[+] afterConnectionEstablished :: " + email);
         } else {
-            // TODO: 로그인 안 되어있을 때 예외처리
+            throw new GeneralException(ErrorStatus.WEBSOCKET_LOGIN_REQUIRED);
         }
     }
 

--- a/src/main/java/kkukmoa/kkukmoa/config/websocket/handler/QrWebSocketHandler.java
+++ b/src/main/java/kkukmoa/kkukmoa/config/websocket/handler/QrWebSocketHandler.java
@@ -44,6 +44,7 @@ public class QrWebSocketHandler extends TextWebSocketHandler {
         clientSessions.put(session.getId(), session);
 
         String email = (String) session.getAttributes().get("email");
+        log.info("[+] afterConnectionEstablished :: " + email);
         if (email != null) {
             emailSessionMap.put(email, session);
             log.info("[+] afterConnectionEstablished :: " + email);

--- a/src/main/java/kkukmoa/kkukmoa/config/websocket/handler/QrWebSocketHandler.java
+++ b/src/main/java/kkukmoa/kkukmoa/config/websocket/handler/QrWebSocketHandler.java
@@ -44,7 +44,7 @@ public class QrWebSocketHandler extends TextWebSocketHandler {
         clientSessions.put(session.getId(), session);
 
         String email = (String) session.getAttributes().get("email");
-        log.info("[+] afterConnectionEstablished :: " + email);
+        log.info("[+] afterConnectionEstablished :: email = " + email);
         if (email != null) {
             emailSessionMap.put(email, session);
             log.info("[+] afterConnectionEstablished :: " + email);


### PR DESCRIPTION
## 📌 작업 개요
웹소켓 인증 방식 수정 및 인증방식 수정

## 🛠 주요 변경 사항
- 인증해야 연결할 수 있도록 변경 
- 웹소켓 인증 방법 Authorization Header -> Sec-WebSocket-Protocol: {access-token}
- 사용자 인증 정보 저장 방식 변경. claim 변경

## 🔗 관련 이슈

## ✅ 테스트 내역
- [x] Swagger 또는 Postman으로 API 테스트 완료
- [x] DB 저장 / 조회 정상 동작 확인
- [x] 기존 기능과 충돌 없음 확인
- [x] 예외 케이스 (에러 응답 등) 테스트

## ⚠️ 영향도 및 주의사항
- 사장님 부분 인증 방식 변경 필요

## 📸 스크린샷 / API 캡처

## 💬 기타 참고 사항
TODO: 추후 리팩터링 예정
