### PR TITLE
[FEAT][mumi]: 닉네임 중복 검사 API 구현

### DIFF
--- a/src/main/java/kkukmoa/kkukmoa/config/security/SecurityConfig.java
+++ b/src/main/java/kkukmoa/kkukmoa/config/security/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
                                                 "/v1/users/login/local",
                                                 "/v1/users/verification/**",
                                                 "/v1/users/signup",
+                                                "/v1/users/nickname/exists",
                                                 "/v1/public/registrations/check-pending",
                                                 "/ws/**",
                                                 "/health", // 인프라 상태검사

--- a/src/main/java/kkukmoa/kkukmoa/user/controller/UserController.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/controller/UserController.java
@@ -246,9 +246,8 @@ public class UserController {
     @GetMapping("/nickname/exists")
     @Operation(summary = "닉네임 중복 확인 API", description = "로컬 회원가입 시, 닉네임 중복 확인을 합니다.")
     public ResponseEntity<ApiResponse<Boolean>> nicknameExists(
-            @Parameter(description = "중복 확인할 닉네임", required = true)
-            @RequestParam("nickname") String nickname
-    ) {
+            @Parameter(description = "중복 확인할 닉네임", required = true) @RequestParam("nickname")
+                    String nickname) {
         boolean exists = userCommandService.isNicknameTaken(nickname);
         return ResponseEntity.ok(ApiResponse.onSuccess(exists));
     }

--- a/src/main/java/kkukmoa/kkukmoa/user/controller/UserController.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/controller/UserController.java
@@ -242,4 +242,14 @@ public class UserController {
         registrationService.signup(req);
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("/nickname/exists")
+    @Operation(summary = "닉네임 중복 확인 API", description = "로컬 회원가입 시, 닉네임 중복 확인을 합니다.")
+    public ResponseEntity<ApiResponse<Boolean>> nicknameExists(
+            @Parameter(description = "중복 확인할 닉네임", required = true)
+            @RequestParam("nickname") String nickname
+    ) {
+        boolean exists = userCommandService.isNicknameTaken(nickname);
+        return ResponseEntity.ok(ApiResponse.onSuccess(exists));
+    }
 }

--- a/src/main/java/kkukmoa/kkukmoa/user/service/UserCommandService.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/service/UserCommandService.java
@@ -1,6 +1,5 @@
 package kkukmoa.kkukmoa.user.service;
 
-
 import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
 import kkukmoa.kkukmoa.apiPayload.exception.handler.UserHandler;
 import kkukmoa.kkukmoa.common.util.AuthService;

--- a/src/main/java/kkukmoa/kkukmoa/user/service/UserCommandService.java
+++ b/src/main/java/kkukmoa/kkukmoa/user/service/UserCommandService.java
@@ -1,6 +1,5 @@
 package kkukmoa.kkukmoa.user.service;
 
-import jakarta.transaction.Transactional;
 
 import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
 import kkukmoa.kkukmoa.apiPayload.exception.handler.UserHandler;
@@ -23,6 +22,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -170,6 +170,14 @@ public class UserCommandService {
         log.info("로그아웃 완료 - userId: {}, Access Token 블랙리스트 등록", user.getId());
     }
 
+    @Transactional(readOnly = true)
+    public boolean isNicknameTaken(String nickname) {
+        if (nickname == null || nickname.trim().isEmpty()) {
+            throw new UserHandler(ErrorStatus.INVALID_PARAMETER);
+        }
+        return userRepository.existsByNicknameIgnoreCase(nickname.trim());
+    }
+
     @Transactional
     public void registerLocalUser(LocalSignupRequestDto request) {
         // 이메일 중복 체크
@@ -177,20 +185,15 @@ public class UserCommandService {
             throw new UserHandler(ErrorStatus.DUPLICATION_DUPLICATION_EMAIL);
         }
 
-        // 닉네임 중복 체크
-        String nick = request.getNickname();
-        if (nick == null || nick.trim().isEmpty()) {
-            throw new UserHandler(ErrorStatus.INVALID_PARAMETER);
-        }
-        if (userRepository.existsByNicknameIgnoreCase(nick.trim())) {
-            throw new UserHandler(ErrorStatus.DUPLICATION_NICKNAME); // 전용 코드
+        if (isNicknameTaken(request.getNickname())) {
+            throw new UserHandler(ErrorStatus.DUPLICATION_NICKNAME);
         }
 
         // 사용자 생성 (시연용: 최소 필드만)
         User user =
                 User.builder()
                         .email(request.getEmail())
-                        .password(passwordEncoder.encode(request.getPassword())) // 비밀번호는 반드시 해시
+                        .password(passwordEncoder.encode(request.getPassword()))
                         .nickname(request.getNickname())
                         .birthday(request.getBirthday())
                         .socialType(SocialType.LOCAL) // 로컬 가입 표시


### PR DESCRIPTION
## 📌 작업 개요
닉네임 중복 검사 API 구현

## 🛠 주요 변경 사항
- 닉네임 중복 검사 로직 추가

## 🔗 관련 이슈
#139 

## ✅ 테스트 내역
- [ ] Swagger 또는 Postman으로 API 테스트 완료
- [ ] DB 저장 / 조회 정상 동작 확인
- [ ] 기존 기능과 충돌 없음 확인
- [ ] 예외 케이스 (에러 응답 등) 테스트

## ⚠️ 영향도 및 주의사항
- 로그인 응답 포맷 변경 (프론트 반영 필요)
- 기존 사용자 인증 방식과 충돌 없음

## 📸 스크린샷 / API 캡처
(스크린샷 drag & drop)

## 💬 기타 참고 사항
TODO: 추후 리팩터링 예정
