### PR TITLE
[FEAT][junyong]: 사장 & 관리자 API 권한 설정

### DIFF
--- a/src/main/java/kkukmoa/kkukmoa/admin/controller/AdminController.java
+++ b/src/main/java/kkukmoa/kkukmoa/admin/controller/AdminController.java
@@ -44,7 +44,7 @@ public class AdminController {
                 description = "잘못된 상태 전환 또는 이미 승인됨(STORE4101/STORE4004)")
     })
     @PostMapping("/stores/{storeId}/approve")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('ADMIN')")
     public ResponseEntity<ApiResponse<String>> approve(@PathVariable Long storeId) {
         adminCommandService.approve(storeId);
         // HTTP 상태코드 200 OK + 바디에 메시지
@@ -53,7 +53,7 @@ public class AdminController {
 
     @GetMapping("/pending")
     @Operation(summary = "승인 대기 목록 조회", description = "입점 신청 상태가 PENDING인 항목을 9개/페이지로 조회")
-    @PreAuthorize("hasRole('ADMIN')") // 관리자만 접근
+    @PreAuthorize("hasAuthority('ADMIN')") // 관리자만 접근
     public ApiResponse<PageDto<PendingStoreSummary>> pending(
             @Parameter(description = "0부터 시작") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "기본 9, 최대 50") @RequestParam(defaultValue = "9") int size) {
@@ -63,6 +63,7 @@ public class AdminController {
 
     @Operation(summary = "입점신청 단건 상세(대기 중)", description = "PENDING 상태의 특정 신청을 상세 조회합니다.")
     @GetMapping("/pending/{storeId}")
+    @PreAuthorize("hasAuthority('ADMIN')") // 관리자만 접근
     public ApiResponse<OwnerRegisterResponse> getPendingDetail(
             @Parameter(description = "스토어 ID", example = "137") @PathVariable Long storeId) {
         OwnerRegisterResponse dto = adminQueryService.getPendingDetail(storeId);

--- a/src/main/java/kkukmoa/kkukmoa/owner/controller/OwnerController.java
+++ b/src/main/java/kkukmoa/kkukmoa/owner/controller/OwnerController.java
@@ -16,6 +16,7 @@ import kkukmoa.kkukmoa.voucher.service.VoucherCommandService;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -43,6 +44,7 @@ public class OwnerController {
                     """)
     @ApiErrorCodeExamples(
             value = {ErrorStatus.AUTHENTICATION_FAILED, ErrorStatus.OWNER_STORE_NOT_FOUND})
+    @PreAuthorize("hasAuthority('OWNER')")
     public ApiResponse<OwnerQrResponseDto.QrDto> getStampQrCode() {
         OwnerQrResponseDto.QrDto stamp = ownerQueryService.getStamp();
         return ApiResponse.onSuccess(stamp);
@@ -63,6 +65,7 @@ public class OwnerController {
         ErrorStatus.QR_INVALID_TYPE,
         ErrorStatus.VOUCHER_NOT_FOUND
     })
+    @PreAuthorize("hasAuthority('OWNER')")
     public ApiResponse<OwnerQrResponseDto.QrTypeDto> getQrCode(
             @RequestParam("qr-uuid") String qrCode) {
 
@@ -92,6 +95,7 @@ public class OwnerController {
         ErrorStatus.AUTHENTICATION_FAILED
     })
     @PatchMapping("/use/voucher/{qr-uuid}")
+    @PreAuthorize("hasAuthority('OWNER')")
     public ApiResponse<VoucherResponseDto.VoucherDeductResponseDto> useVoucher(
             @Parameter(
                             description =
@@ -122,6 +126,7 @@ public class OwnerController {
         ErrorStatus.COUPON_INVALID_USED_PLACE,
         ErrorStatus.COUPON_IS_USED
     })
+    @PreAuthorize("hasAuthority('OWNER')")
     public ApiResponse<CouponUseDto> useCoupon(
             @Parameter(
                             description =

--- a/src/main/java/kkukmoa/kkukmoa/owner/controller/OwnerRegisterCheckController.java
+++ b/src/main/java/kkukmoa/kkukmoa/owner/controller/OwnerRegisterCheckController.java
@@ -39,7 +39,7 @@ public class OwnerRegisterCheckController {
 
     @Operation(summary = "PENDING 존재여부 확인 (로그인)", description = "현재 로그인한 사용자 기준 PENDING 상태 여부 반환")
     @GetMapping("/owners/registrations/check-pending")
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("hasAuthority('PENDING_OWNER')")
     public ApiResponse<OwnerRegisterCheckResponse> checkPendingLogin(
             @AuthenticationPrincipal(expression = "id") Long userId) {
         return ApiResponse.onSuccess(service.checkPendingForUser(userId));


### PR DESCRIPTION
## 📌 작업 개요
API 호출 권한 설정

## 🛠 주요 변경 사항
- Owner API, Admin API 권한 제한
- @PreAuthorize 어노테이션 추가


## ✅ 테스트 내역
- [x] Swagger 또는 Postman으로 API 테스트 완료
- [x] DB 저장 / 조회 정상 동작 확인
- [x] 기존 기능과 충돌 없음 확인
- [x] 예외 케이스 (에러 응답 등) 테스트

## ⚠️ 영향도 및 주의사항
- 테스트 및 연동 시 권한 주의
