### PR TITLE
[FIX][jjaeroong]: 토스 결제 승인 요청 시 토큰 successUrl 파라미터 전달

### DIFF
--- a/src/main/resources/templates/TossPayment.html
+++ b/src/main/resources/templates/TossPayment.html
@@ -221,8 +221,8 @@
             await widgets.requestPayment({
                 orderId: prepareData.orderId,
                 orderName: prepareData.orderName,
-                successUrl: window.location.href,
-                failUrl: window.location.href + "?fail=true",
+                successUrl: `${window.location.origin}${window.location.pathname}?paymentKey=${prepareData.paymentKey}&orderId=${prepareData.orderId}&amount=${prepareData.amount}&token=${encodeURIComponent(token)}`,
+                failUrl: `${window.location.href}?fail=true`
             });
         });
 
@@ -231,28 +231,25 @@
         const paymentKey = params.get("paymentKey");
         const orderId = params.get("orderId");
         const amount = parseInt(params.get("amount") || "0", 10);
+        const tokenParam = params.get("token");
+        const tokenToUse = tokenParam || localStorage.getItem("kkukmoa_token");
 
-        if (paymentKey && orderId && amount) {
-            const storedToken = localStorage.getItem("kkukmoa_token");
-            console.log("결제 승인 요청:", storedToken)
-
-
-            const headers = {
-                "Content-Type": "application/json",
-                "Authorization": `Bearer ${storedToken}`
-            };
-
+        if (paymentKey && orderId && amount && tokenToUse) {
+            console.log("결제 승인 요청:", tokenToUse);
 
             const confirmRes = await fetch("https://kkukmoa.shop/v1/payments/confirm", {
                 method: "POST",
-                headers,
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${tokenToUse}`
+                },
                 body: JSON.stringify({
                     paymentKey,
                     orderId,
                     amount,
                     voucherUnitPrice: unitPrice,
                     voucherQuantity: quantity
-                }),
+                })
             });
 
             const confirmJson = await confirmRes.json();


### PR DESCRIPTION
## 📌 작업 개요
카카오 로그인 연동 및 JWT 발급 기능 추가

## 🛠 주요 변경 사항
- UserCommandService: 카카오 토큰 조회 로직 추가
- JwtProvider: JWT 생성 메서드 구현

## 🔗 관련 이슈
#12

## ✅ 테스트 내역
- [ ] Swagger 또는 Postman으로 API 테스트 완료
- [ ] DB 저장 / 조회 정상 동작 확인
- [ ] 기존 기능과 충돌 없음 확인
- [ ] 예외 케이스 (에러 응답 등) 테스트

## ⚠️ 영향도 및 주의사항
- 로그인 응답 포맷 변경 (프론트 반영 필요)
- 기존 사용자 인증 방식과 충돌 없음

## 📸 스크린샷 / API 캡처
(스크린샷 drag & drop)

## 💬 기타 참고 사항
TODO: 추후 리팩터링 예정
