### PR TITLE
[FIX][jjaeroong]: 토스 결제 승인 요청 시 토큰 접두사 제거 및 successUrl 파라미터 전달 시 pamentKey 제거

### DIFF
--- a/src/main/java/kkukmoa/kkukmoa/payment/controller/PaymentViewController.java
+++ b/src/main/java/kkukmoa/kkukmoa/payment/controller/PaymentViewController.java
@@ -43,15 +43,14 @@ public class PaymentViewController {
     public String tossPayPage(
             @RequestParam("unitPrice") int unitPrice,
             @RequestParam("quantity") int quantity,
-            Model model
-    ) {
+            Model model) {
 
-        String hardcodedToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqeTgyOTRAZGF1bS5uZXQiLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNzU1MjQyMTgyLCJleHAiOjE3NTY1MzgxODJ9.COEn4ZxnzIonru2ItV50j_8eSQ9i8toMwBzfCkm91uI"; // 예시 토큰, 실제로는 유효한 토큰을 사용해야 합니다.
+        String hardcodedToken =
+                "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqeTgyOTRAZGF1bS5uZXQiLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNzU1MjQyMTgyLCJleHAiOjE3NTY1MzgxODJ9.COEn4ZxnzIonru2ItV50j_8eSQ9i8toMwBzfCkm91uI"; // 예시 토큰, 실제로는 유효한 토큰을 사용해야 합니다.
         model.addAttribute("token", hardcodedToken);
         model.addAttribute("clientKey", tossClientKey);
         model.addAttribute("unitPrice", unitPrice);
         model.addAttribute("quantity", quantity);
         return "TossPayment";
     }
-
 }

--- a/src/main/java/kkukmoa/kkukmoa/payment/controller/PaymentViewController.java
+++ b/src/main/java/kkukmoa/kkukmoa/payment/controller/PaymentViewController.java
@@ -28,10 +28,30 @@ public class PaymentViewController {
             @RequestParam("unitPrice") int unitPrice,
             @RequestParam("quantity") int quantity,
             Model model) {
-        model.addAttribute("token", authHeader);
+
+        // "Bearer " 제거
+        String token = authHeader.replaceFirst("(?i)^Bearer ", "").trim();
+
+        model.addAttribute("token", token);
         model.addAttribute("clientKey", tossClientKey);
         model.addAttribute("unitPrice", unitPrice);
         model.addAttribute("quantity", quantity);
         return "TossPayment";
     }
+
+    @GetMapping("/test")
+    public String tossPayPage(
+            @RequestParam("unitPrice") int unitPrice,
+            @RequestParam("quantity") int quantity,
+            Model model
+    ) {
+
+        String hardcodedToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqeTgyOTRAZGF1bS5uZXQiLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNzU1MjQyMTgyLCJleHAiOjE3NTY1MzgxODJ9.COEn4ZxnzIonru2ItV50j_8eSQ9i8toMwBzfCkm91uI"; // 예시 토큰, 실제로는 유효한 토큰을 사용해야 합니다.
+        model.addAttribute("token", hardcodedToken);
+        model.addAttribute("clientKey", tossClientKey);
+        model.addAttribute("unitPrice", unitPrice);
+        model.addAttribute("quantity", quantity);
+        return "TossPayment";
+    }
+
 }

--- a/src/main/resources/templates/TossPayment.html
+++ b/src/main/resources/templates/TossPayment.html
@@ -221,8 +221,8 @@
             await widgets.requestPayment({
                 orderId: prepareData.orderId,
                 orderName: prepareData.orderName,
-                successUrl: window.location.href,
-                failUrl: window.location.href + "?fail=true",
+                successUrl: `${window.location.origin}${window.location.pathname}?paymentKey=${prepareData.paymentKey}&orderId=${prepareData.orderId}&amount=${prepareData.amount}&token=${encodeURIComponent(token)}`,
+                failUrl: `${window.location.href}?fail=true`
             });
         });
 
@@ -231,28 +231,25 @@
         const paymentKey = params.get("paymentKey");
         const orderId = params.get("orderId");
         const amount = parseInt(params.get("amount") || "0", 10);
+        const tokenParam = params.get("token");
+        const tokenToUse = tokenParam || localStorage.getItem("kkukmoa_token");
 
-        if (paymentKey && orderId && amount) {
-            const storedToken = localStorage.getItem("kkukmoa_token");
-            console.log("결제 승인 요청:", storedToken)
-
-
-            const headers = {
-                "Content-Type": "application/json",
-                "Authorization": `Bearer ${storedToken}`
-            };
-
+        if (paymentKey && orderId && amount && tokenToUse) {
+            console.log("결제 승인 요청:", tokenToUse);
 
             const confirmRes = await fetch("https://kkukmoa.shop/v1/payments/confirm", {
                 method: "POST",
-                headers,
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${tokenToUse}`
+                },
                 body: JSON.stringify({
                     paymentKey,
                     orderId,
                     amount,
                     voucherUnitPrice: unitPrice,
                     voucherQuantity: quantity
-                }),
+                })
             });
 
             const confirmJson = await confirmRes.json();

--- a/src/main/resources/templates/TossPayment.html
+++ b/src/main/resources/templates/TossPayment.html
@@ -155,23 +155,24 @@
     const token = /*[[${token}]]*/ "";
     const unitPrice = /*[[${unitPrice}]]*/ 0;
     const quantity  = /*[[${quantity}]]*/ 0;
+
     if (token) {
         localStorage.setItem("kkukmoa_token", token);
     }
+
     main();
 
     async function main() {
         const button = document.getElementById("payment-button");
         const baseAmount = unitPrice * quantity;
 
-        // 토스 위젯 초기화
         const clientKey = /*[[${clientKey}]]*/ "";
         const tossPayments = TossPayments(clientKey);
 
         // customerKey 생성
         const customerKey = await fetch("https://kkukmoa.shop/v1/users/uuid", {
             method: "GET",
-            headers: { "Authorization": token }
+            headers: { "Authorization": `Bearer ${token}` }
         })
             .then(res => res.json())
             .then(data => "user_" + data.result)
@@ -185,7 +186,6 @@
 
         const widgets = tossPayments.widgets({ customerKey });
 
-        // 결제 금액 세팅
         await widgets.setAmount({ currency: "KRW", value: baseAmount });
 
         await Promise.all([
@@ -193,13 +193,13 @@
             widgets.renderAgreement({ selector: "#agreement", variantKey: "AGREEMENT" }),
         ]);
 
-        // 결제 버튼 클릭 이벤트
+        // 결제 요청
         button.addEventListener("click", async function () {
             const prepareRes = await fetch("https://kkukmoa.shop/v1/payments/prepare", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    "Authorization": token
+                    "Authorization": `Bearer ${token}`
                 },
                 body: JSON.stringify({
                     orderName: `꾹모아 금액권 ${unitPrice}원권`,
@@ -221,9 +221,10 @@
             await widgets.requestPayment({
                 orderId: prepareData.orderId,
                 orderName: prepareData.orderName,
-                successUrl: `${window.location.origin}${window.location.pathname}?paymentKey=${prepareData.paymentKey}&orderId=${prepareData.orderId}&amount=${prepareData.amount}&token=${encodeURIComponent(token)}`,
+                successUrl: `${window.location.origin}${window.location.pathname}?orderId=${prepareData.orderId}&amount=${prepareData.amount}&token=${encodeURIComponent(token)}&unitPrice=${unitPrice}&quantity=${quantity}`,
                 failUrl: `${window.location.href}?fail=true`
             });
+
         });
 
         // 결제 승인 처리
@@ -231,6 +232,8 @@
         const paymentKey = params.get("paymentKey");
         const orderId = params.get("orderId");
         const amount = parseInt(params.get("amount") || "0", 10);
+        const unitPriceParam = parseInt(params.get("unitPrice") || "0", 10);
+        const quantityParam = parseInt(params.get("quantity") || "1", 10);
         const tokenParam = params.get("token");
         const tokenToUse = tokenParam || localStorage.getItem("kkukmoa_token");
 
@@ -247,8 +250,8 @@
                     paymentKey,
                     orderId,
                     amount,
-                    voucherUnitPrice: unitPrice,
-                    voucherQuantity: quantity
+                    voucherUnitPrice: unitPriceParam,
+                    voucherQuantity: quantityParam
                 })
             });
 
@@ -264,5 +267,6 @@
         }
     }
 </script>
+
 </body>
 </html>

--- a/src/main/resources/templates/TossPayment.html
+++ b/src/main/resources/templates/TossPayment.html
@@ -236,8 +236,12 @@
             const storedToken = localStorage.getItem("kkukmoa_token");
             console.log("결제 승인 요청:", storedToken)
 
-            const headers = { "Content-Type": "application/json" };
-            if (storedToken) headers["Authorization"] = storedToken;
+
+            const headers = {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${storedToken}`
+            };
+
 
             const confirmRes = await fetch("https://kkukmoa.shop/v1/payments/confirm", {
                 method: "POST",


### PR DESCRIPTION
## 📌 작업 개요
카카오 로그인 연동 및 JWT 발급 기능 추가

## 🛠 주요 변경 사항
- UserCommandService: 카카오 토큰 조회 로직 추가
- JwtProvider: JWT 생성 메서드 구현

## 🔗 관련 이슈
#12

## ✅ 테스트 내역
- [ ] Swagger 또는 Postman으로 API 테스트 완료
- [ ] DB 저장 / 조회 정상 동작 확인
- [ ] 기존 기능과 충돌 없음 확인
- [ ] 예외 케이스 (에러 응답 등) 테스트

## ⚠️ 영향도 및 주의사항
- 로그인 응답 포맷 변경 (프론트 반영 필요)
- 기존 사용자 인증 방식과 충돌 없음

## 📸 스크린샷 / API 캡처
(스크린샷 drag & drop)

## 💬 기타 참고 사항
TODO: 추후 리팩터링 예정
