### PR TITLE
[Refactor][jjaeroong]: 토스 결제 승인 API 분리

### DIFF
--- a/src/main/java/kkukmoa/kkukmoa/common/util/AuthService.java
+++ b/src/main/java/kkukmoa/kkukmoa/common/util/AuthService.java
@@ -2,6 +2,7 @@ package kkukmoa.kkukmoa.common.util;
 
 import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
 import kkukmoa.kkukmoa.apiPayload.exception.handler.UserHandler;
+import kkukmoa.kkukmoa.config.security.JwtTokenProvider;
 import kkukmoa.kkukmoa.user.domain.User;
 import kkukmoa.kkukmoa.user.repository.UserRepository;
 
@@ -18,7 +19,7 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final UserRepository userRepository;
-
+    private final JwtTokenProvider jwtTokenProvider;
     public User getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
@@ -32,6 +33,12 @@ public class AuthService {
         }
 
         return user;
+    }
+    public User getUserFromToken(String token) {
+        String email = jwtTokenProvider.getSubjectFromToken(token); // 여기 사용
+
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
     }
 
     public Long getCurrentUserId() {

--- a/src/main/java/kkukmoa/kkukmoa/payment/controller/PaymentController.java
+++ b/src/main/java/kkukmoa/kkukmoa/payment/controller/PaymentController.java
@@ -3,9 +3,11 @@ package kkukmoa.kkukmoa.payment.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import jakarta.servlet.http.HttpServletResponse;
 import kkukmoa.kkukmoa.apiPayload.code.status.ErrorStatus;
 import kkukmoa.kkukmoa.apiPayload.exception.ApiResponse;
 import kkukmoa.kkukmoa.common.util.swagger.ApiErrorCodeExamples;
+import kkukmoa.kkukmoa.payment.converter.PaymentConverter;
 import kkukmoa.kkukmoa.payment.domain.Payment;
 import kkukmoa.kkukmoa.payment.dto.request.PaymentRequestDto;
 import kkukmoa.kkukmoa.payment.dto.response.PaymentPrepareResponseDto;
@@ -17,6 +19,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+import java.net.URLEncoder;
+
 @Tag(name = "토스 결제 API", description = "토스 결제 API 입니다.")
 @Slf4j
 @RequiredArgsConstructor
@@ -24,7 +29,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v1/payments")
 public class PaymentController {
     private final PaymentCommandService paymentService;
-
+    private final PaymentConverter paymentConverter;
     @Operation(
             summary = "결제 준비 API",
             description =
@@ -67,4 +72,31 @@ public class PaymentController {
         Payment payment = paymentService.confirm(request);
         return ResponseEntity.ok(ApiResponse.onSuccess("결제 성공: " + payment.getId()));
     }
+    @GetMapping("/toss/success")
+    public void tossPaymentSuccess(
+            @RequestParam String paymentKey,
+            @RequestParam String orderId,
+            @RequestParam int amount,
+            @RequestParam(required = false) Integer unitPrice,
+            @RequestParam(required = false) Integer quantity,
+            @RequestParam String token,
+            HttpServletResponse response) throws IOException {
+
+        PaymentRequestDto.PaymentConfirmRequestDto confirmDto = PaymentConverter.toConfirmDto(
+                paymentKey,
+                orderId,
+                amount,
+                unitPrice,
+                quantity
+        );
+
+        try {
+            paymentService.confirm(confirmDto, token);
+            response.sendRedirect("kkukmoa://app/myGiftCard/MyGiftCardScreen");
+        } catch (Exception e) {
+            response.sendRedirect("kkukmoa://app/paymentFail?message=" + URLEncoder.encode(e.getMessage(), "UTF-8"));
+        }
+    }
+
+
 }

--- a/src/main/java/kkukmoa/kkukmoa/payment/controller/PaymentViewController.java
+++ b/src/main/java/kkukmoa/kkukmoa/payment/controller/PaymentViewController.java
@@ -38,4 +38,5 @@ public class PaymentViewController {
         model.addAttribute("quantity", quantity);
         return "TossPayment";
     }
+
 }

--- a/src/main/java/kkukmoa/kkukmoa/payment/converter/PaymentConverter.java
+++ b/src/main/java/kkukmoa/kkukmoa/payment/converter/PaymentConverter.java
@@ -22,4 +22,20 @@ public class PaymentConverter {
                 .user(user)
                 .build();
     }
+    public static PaymentRequestDto.PaymentConfirmRequestDto toConfirmDto(
+            String paymentKey,
+            String orderId,
+            int amount,
+            Integer unitPrice,
+            Integer quantity
+    ) {
+        return PaymentRequestDto.PaymentConfirmRequestDto.builder()
+                .paymentKey(paymentKey)
+                .orderId(orderId)
+                .amount(amount)
+                .voucherUnitPrice(unitPrice)
+                .voucherQuantity(quantity)
+                .build();
+    }
+
 }

--- a/src/main/java/kkukmoa/kkukmoa/payment/dto/request/PaymentRequestDto.java
+++ b/src/main/java/kkukmoa/kkukmoa/payment/dto/request/PaymentRequestDto.java
@@ -1,6 +1,7 @@
 package kkukmoa.kkukmoa.payment.dto.request;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,6 +29,7 @@ public class PaymentRequestDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Builder
     public static class PaymentConfirmRequestDto {
         private String paymentKey;
         private String orderId;

--- a/src/main/java/kkukmoa/kkukmoa/payment/service/PaymentCommandService.java
+++ b/src/main/java/kkukmoa/kkukmoa/payment/service/PaymentCommandService.java
@@ -73,20 +73,32 @@ public class PaymentCommandService {
     }
 
     @Transactional
+    public Payment confirm(PaymentRequestDto.PaymentConfirmRequestDto req, String token) {
+        log.info("[결제 확인: 토큰 기반] orderId: {}", req.getOrderId());
+
+        User user = authService.getUserFromToken(token);
+        return internalConfirm(req, user);
+    }
+
+    @Transactional
     public Payment confirm(PaymentRequestDto.PaymentConfirmRequestDto req) {
+        log.info("[결제 확인: 인증 유저 기반] orderId: {}", req.getOrderId());
+
+        User user = authService.getCurrentUser(); // 🔐 기존 방식 유지
+        return internalConfirm(req, user);
+    }
+
+    private Payment internalConfirm(PaymentRequestDto.PaymentConfirmRequestDto req, User user) {
         log.info("[결제 확인] 요청 orderId: {}, amount: {}", req.getOrderId(), req.getAmount());
 
         // 1. Redis에서 사전 저장된 결제 정보 조회
         PaymentRequestDto.PaymentPrepareRequestDto prepare =
                 redisRepository
                         .findByOrderId(req.getOrderId())
-                        .orElseThrow(
-                                () -> {
-                                    log.error(
-                                            "[결제 확인 실패] Redis에서 orderId={} 정보 없음",
-                                            req.getOrderId());
-                                    return new PaymentHandler(ErrorStatus.PAYMENT_INFO_NOT_FOUND);
-                                });
+                        .orElseThrow(() -> {
+                            log.error("[결제 확인 실패] Redis에서 orderId={} 정보 없음", req.getOrderId());
+                            return new PaymentHandler(ErrorStatus.PAYMENT_INFO_NOT_FOUND);
+                        });
 
         // 2. 금액 무결성 검증
         if (req.getAmount() != prepare.getAmount()) {
@@ -95,31 +107,28 @@ public class PaymentCommandService {
         }
 
         // 3. Toss 결제 승인 요청
-        log.info(
-                "[Toss 요청] paymentKey={}, orderId={}, amount={}",
-                req.getPaymentKey(),
-                req.getOrderId(),
-                req.getAmount());
+        log.info("[Toss 요청] paymentKey={}, orderId={}, amount={}",
+                req.getPaymentKey(), req.getOrderId(), req.getAmount());
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        String encodedKey =
-                Base64.getEncoder()
-                        .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+        String encodedKey = Base64.getEncoder()
+                .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
         headers.set("Authorization", "Basic " + encodedKey);
 
-        Map<String, Object> body =
-                Map.of(
-                        "paymentKey", req.getPaymentKey(),
-                        "orderId", req.getOrderId(),
-                        "amount", req.getAmount());
+        Map<String, Object> body = Map.of(
+                "paymentKey", req.getPaymentKey(),
+                "orderId", req.getOrderId(),
+                "amount", req.getAmount()
+        );
 
         HttpEntity<?> entity = new HttpEntity<>(body, headers);
-        ResponseEntity<TossPaymentConfirmResponseDto> response =
-                restTemplate.postForEntity(
-                        "https://api.tosspayments.com/v1/payments/confirm",
-                        entity,
-                        TossPaymentConfirmResponseDto.class);
+
+        ResponseEntity<TossPaymentConfirmResponseDto> response = restTemplate.postForEntity(
+                "https://api.tosspayments.com/v1/payments/confirm",
+                entity,
+                TossPaymentConfirmResponseDto.class
+        );
 
         TossPaymentConfirmResponseDto res = response.getBody();
         if (res == null) {
@@ -128,7 +137,6 @@ public class PaymentCommandService {
         }
 
         // 4. 결제 정보 저장
-        User user = authService.getCurrentUser();
         Payment payment = PaymentConverter.toEntity(prepare, user);
         payment.updateFromTossResponse(res);
         paymentRepository.save(payment);
@@ -137,11 +145,8 @@ public class PaymentCommandService {
         int unitPrice = prepare.getVoucherUnitPrice();
         int quantity = prepare.getVoucherQuantity();
 
-        log.info(
-                "[금액권 발급 시도] orderId={}, unitPrice={}, quantity={}",
-                req.getOrderId(),
-                unitPrice,
-                quantity);
+        log.info("[금액권 발급 시도] orderId={}, unitPrice={}, quantity={}",
+                req.getOrderId(), unitPrice, quantity);
         voucherCommandService.issueVouchersByQr(unitPrice, quantity, user, payment);
 
         return payment;

--- a/src/main/resources/templates/TossPayment.html
+++ b/src/main/resources/templates/TossPayment.html
@@ -220,9 +220,12 @@
             await widgets.requestPayment({
                 orderId: prepareData.orderId,
                 orderName: prepareData.orderName,
-                successUrl: `${window.location.origin}/payment/TossSuccess.html`,
-                failUrl: `${window.location.origin}/payment/fail.html`
+                successUrl: `https://kkukmoa.shop/v1/payments/toss/success?token=${encodeURIComponent(token)}&unitPrice=${unitPrice}&quantity=${quantity}`,
+                failUrl: `https://kkukmoa.shop/v1/payments/toss/fail`,
             });
+
+
+
 
 
         })


### PR DESCRIPTION
## 📌 작업 개요
토스 결제 승인 API 분리

## 🛠 주요 변경 사항
- UserCommandService: 카카오 토큰 조회 로직 추가
- JwtProvider: JWT 생성 메서드 구현

## 🔗 관련 이슈
#12

## ✅ 테스트 내역
- [ ] Swagger 또는 Postman으로 API 테스트 완료
- [ ] DB 저장 / 조회 정상 동작 확인
- [ ] 기존 기능과 충돌 없음 확인
- [ ] 예외 케이스 (에러 응답 등) 테스트

## ⚠️ 영향도 및 주의사항
- 로그인 응답 포맷 변경 (프론트 반영 필요)
- 기존 사용자 인증 방식과 충돌 없음

## 📸 스크린샷 / API 캡처
(스크린샷 drag & drop)

## 💬 기타 참고 사항
TODO: 추후 리팩터링 예정
