### PR TITLE
[Fix][jjaeroong]: 금액 함수 미적용 오류 수정

### DIFF
--- a/src/main/resources/templates/TossPayment.html
+++ b/src/main/resources/templates/TossPayment.html
@@ -200,7 +200,7 @@
             widgets.renderPaymentMethods({selector: "#payment-method", variantKey: "DEFAULT"}),
             widgets.renderAgreement({selector: "#agreement", variantKey: "AGREEMENT"}),
         ]);
-
+        const formattedAmount = formatToKoreanWon(unitPrice);
         // 결제 요청
         button.addEventListener("click", async function () {
             const prepareRes = await fetch("https://kkukmoa.shop/v1/payments/prepare", {
@@ -210,7 +210,7 @@
                     "Authorization": `Bearer ${token}`
                 },
                 body: JSON.stringify({
-                        orderName: `꾹모아 금액권 ${formattedAmount}`,
+                    orderName: `꾹모아 금액권 ${formattedAmount}`,
                     amount: baseAmount,
                     voucherUnitPrice: unitPrice,
                     voucherQuantity: quantity


### PR DESCRIPTION
## 📌 작업 개요
금액 함수 미적용 오류 수정

## 🛠 주요 변경 사항
- UserCommandService: 카카오 토큰 조회 로직 추가
- JwtProvider: JWT 생성 메서드 구현

## 🔗 관련 이슈
#12

## ✅ 테스트 내역
- [ ] Swagger 또는 Postman으로 API 테스트 완료
- [ ] DB 저장 / 조회 정상 동작 확인
- [ ] 기존 기능과 충돌 없음 확인
- [ ] 예외 케이스 (에러 응답 등) 테스트

## ⚠️ 영향도 및 주의사항
- 로그인 응답 포맷 변경 (프론트 반영 필요)
- 기존 사용자 인증 방식과 충돌 없음

## 📸 스크린샷 / API 캡처
(스크린샷 drag & drop)

## 💬 기타 참고 사항
TODO: 추후 리팩터링 예정
